### PR TITLE
Close Socket when the site unloads

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -278,6 +278,10 @@ window.App = (function () {
             } catch (e) {
                 console.log('Notifications not available');
             }
+            window.addEventListener("beforeunload", function() {
+                self.socket.close = wpc;
+                self.socket.close();
+            });
         },
         initBoard: function (data) {
             self.width = data.width;


### PR DESCRIPTION
Close Socket when the site unloads, so the Server doesn't retransmit the first packet it tries to send after the Socket doesn't listen anymore (which it does)