### PR TITLE
Fixes console error when saving canvas to PNG

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -732,7 +732,7 @@ window.App = (function () {
                     a.download = "canvas.png";
                     document.body.appendChild(a);
                     a.click();
-                    document.removeChild(a);
+                    document.body.removeChild(a);
                     if (typeof a.remove === "function") {
                         a.remove();
                     }


### PR DESCRIPTION
When saving the canvas to PNG, the temporary 'a' element is added to `document.body` so that FireFox will actually register the click() event.  However, the element was being removed from `document` - throwing an error.  This fixes it by correctly removing it from `document.body` instead.