### PR TITLE
Shift+LMB fix, Allow color switching while on cooldown with "Keep Color Selected" enabled.

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -91,12 +91,13 @@
             You are not signed in. <a href="#">Sign in with...</a>
         </div>
         <div id="user-message" class="palette-overlay"></div>
-        <div id="cooldown-timer" class="palette-overlay"></div>
+        <div id="cd-timer-overlay" class="palette-overlay"></div>
         <div id="palette"></div>
     </div>
 
     <div class="left">
         <div id="coords" class="bubble"></div>
+        <div id="cd-timer-bubble" class="bubble"></div>
     </div>
     <div class="right">
         <div id="userinfo" class="bubble"><span class="name"></span> <a href="/logout" class="logout">logout</a></div>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -524,6 +524,7 @@ window.App = (function () {
                         downX = evt.originalEvent.changedTouches[0].clientX;
                         downY = evt.originalEvent.changedTouches[0].clientY;
                     }).on("pointerup mouseup touchend", function (evt) {
+                        if (evt.shiftKey === true) return;
                         var touch = false,
                             clientX = evt.clientX,
                             clientY = evt.clientY;

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1318,7 +1318,7 @@ window.App = (function () {
                                 .addClass("ontouchstart" in window ? "touch" : "no-touch")
                                 .css("background-color", self.palette[idx])
                                 .click(function () {
-                                    if (timer.cooledDown()) {
+                                    if (ls.get("auto_reset") === false || timer.cooledDown()) {
                                         self.switch(idx);
                                     }
                                 });
@@ -1668,7 +1668,9 @@ window.App = (function () {
         timer = (function() {
             var self = {
                 elements: {
-                    timer: $("#cooldown-timer")
+                    timer_bubble: $("#cd-timer-bubble"),
+                    timer_overlay: $("#cd-timer-overlay"),
+                    timer: null
                 },
                 hasFiredNotification: true,
                 cooldown: 0,
@@ -1683,6 +1685,12 @@ window.App = (function () {
                     // subtract one extra millisecond to prevent the first displaying to be derped
                     var delta = (self.cooldown - (new Date()).getTime() - 1) / 1000;
 
+                    if (self.runningTimer === false) {
+                        self.elements.timer = ls.get("auto_reset") === false ? self.elements.timer_bubble : self.elements.timer_overlay;
+                        self.elements.timer_bubble.hide();
+                        self.elements.timer_overlay.hide();
+                    }
+
                     if (self.status) {
                         self.elements.timer.text(self.status);
                     }
@@ -1695,8 +1703,6 @@ window.App = (function () {
                             minutes = Math.floor(delta / 60),
                             minuteStr = minutes < 10 ? "0" + minutes : minutes;
                         self.elements.timer.text(minuteStr + ":" + secsStr);
-
-                        $(".palette-color").css("cursor", "not-allowed");
 
                         document.title = "[" + minuteStr + ":" + secsStr + "] " + self.title;
 
@@ -1723,11 +1729,11 @@ window.App = (function () {
 
                     document.title = self.title;
                     self.elements.timer.hide();
-                    $(".palette-color").css("cursor", "");
                 },
                 init: function () {
                     self.title = document.title;
-                    self.elements.timer.hide();
+                    self.elements.timer_bubble.hide();
+                    self.elements.timer_overlay.hide();
 
                     $(window).focus(function() {
                         self.focus = true;


### PR DESCRIPTION
This brings two changes:

1) Don't swallow pixel on shift+LMB.
2) Allow color switching while on cooldown with "Keep Color Selected" enabled.

In order to avoid overlapping the timer with the leftmost colors on smaller devices, I have moved the timer to a UI bubble next to coordinates when "Keep Color Selected" is enabled.