### PR TITLE
Some QoL Improvements

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -42,12 +42,13 @@
             <div class="close">Close</div>
             <div>
                 <h1>General settings</h1>
-                <div>
-                    <label><input id="audiotoggle" type="checkbox"/>Mute sound</label><br>
-                    <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap</label><br>
-                    <label><input id="gridtoggle" type="checkbox"/>Turn on grid</label><br>
+                <div class="settingToggles">
+                    <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
+                    <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap</label>
+                    <label><input type="checkbox" id="heatmapClearable">Enable heatmap clearing (hotkey: o)</label>
+                    <label><input id="gridtoggle" type="checkbox"/>Turn on grid</label>
                     <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
-                    <p><label>Heatmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label></p>
+                    <label>Heatmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
                 </div>
             </div>
             <div>
@@ -60,6 +61,7 @@
                 <p>T to toggle template control</p>
                 <p>P to take a snapshot</p>
                 <p>H to toggle heatmap</p>
+                <p>O to clear heatmap (if enabled)</p>
             </div>
             <div>
                 <h1>Template control</h1>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -99,6 +99,7 @@
 
     <div class="left">
         <div id="coords" class="bubble"></div>
+        <div id="heatmapLoadingBubble" class="bubble orange-bubble fat-bubble">Loading heatmap...</div>
         <div id="cd-timer-bubble" class="bubble"></div>
         <div id="placeableInfoBubble" class="bubble">Pixels available: <span id="placeableCount-bubble">0/0</span></div>
     </div>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1049,7 +1049,8 @@ window.App = (function () {
         heatmap = (function() {
             var self = {
                 elements: {
-                    heatmap: $("#heatmap")
+                    heatmap: $("#heatmap"),
+                    heatmapLoadingBubble: $("#heatmapLoadingBubble")
                 },
                 ctx: null,
                 id: null,
@@ -1072,8 +1073,10 @@ window.App = (function () {
                 },
                 lazy_init: function () {
                     if (self.lazy_inited) {
+                        self.elements.heatmapLoadingBubble.hide();
                         return;
                     }
+                    self.elements.heatmapLoadingBubble.show();
                     self.lazy_inited = true;
                     // we use xhr directly because of jquery being weird on raw binary
                     binary_ajax("/heatmap" + "?_" + (new Date()).getTime(), function (data) {
@@ -1087,6 +1090,7 @@ window.App = (function () {
                         }
                         self.ctx.putImageData(self.id, 0, 0);
                         self.elements.heatmap.fadeIn(200);
+                        self.elements.heatmapLoadingBubble.hide();
                         setTimeout(self.loop, self.seconds * 1000 / 256);
                         socket.on("pixel", function (data) {
                             self.ctx.fillStyle = "#CD5C5C";
@@ -1110,6 +1114,7 @@ window.App = (function () {
                 },
                 init: function () {
                     self.elements.heatmap.hide();
+                    self.elements.heatmapLoadingBubble.hide();
                     self.setBackgroundOpacity(ls.get("heatmap_background_opacity"));
                     $("#heatmap-opacity").val(ls.get("heatmap_background_opacity")); //heatmap_background_opacity should always be valid after a call to self.setBackgroundOpacity.
                     $("#heatmap-opacity").on("change input", function() {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1101,6 +1101,17 @@ window.App = (function () {
                         });
                     });
                 },
+                clear: function() {
+                    if (ls.get("hm_clearable") === true) {
+                        self._clear();
+                    }
+                },
+                _clear: function() {
+                    for (var i = 0; i < self.width * self.height; i++) {
+                        self.intView[i] = 0;
+                    }
+                    self.ctx.putImageData(self.id, 0, 0);
+                },
                 setBackgroundOpacity: function(opacity) {
                     if (typeof(opacity) === "string") {
                         opacity = parseFloat(opacity);
@@ -1119,6 +1130,15 @@ window.App = (function () {
                     $("#heatmap-opacity").val(ls.get("heatmap_background_opacity")); //heatmap_background_opacity should always be valid after a call to self.setBackgroundOpacity.
                     $("#heatmap-opacity").on("change input", function() {
                         self.setBackgroundOpacity(parseFloat(this.value));
+                    });
+                    $("#heatmapClearable")[0].checked = ls.get("hm_clearable");
+                    $("#heatmapClearable").change(function () {
+                        ls.set("hm_clearable", this.checked);
+                    });
+                    $(window).keydown(function (evt) {
+                        if (evt.which == 79) { //O key
+                            self.clear();
+                        }
                     });
                 },
                 show: function () {
@@ -1177,7 +1197,8 @@ window.App = (function () {
                 init: self.init,
                 webinit: self.webinit,
                 toggle: self.toggle,
-                setBackgroundOpacity: self.setBackgroundOpacity
+                setBackgroundOpacity: self.setBackgroundOpacity,
+                clear: self.clear
             };
         })(),
         // here all the template stuff happens
@@ -2326,6 +2347,9 @@ window.App = (function () {
         ls: ls,
         ss: ss,
         query: query,
+        heatmap: {
+            clear: heatmap.clear
+        },
         template: {
             update: function(t) {
                 template.queueUpdate(t);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1958,6 +1958,7 @@ window.App = (function () {
                 },
                 updateStacked: function(count, cause) {
                     if (count > 0 && cause === "gain") timer.playAudio();
+                    if (count === 0 && cause === "connect") return self.setPlaceableText(0);
                     self.setPlaceableText(count+1);
                 },
                 setMax(maxStacked) {
@@ -2056,7 +2057,7 @@ window.App = (function () {
                         self.focus = false;
                     });
                     setTimeout(function() {
-                        if (!self.cooledDown()) {
+                        if (self.cooledDown() && stackHelper.getStacked() === 0) {
                             stackHelper.setPlaceableText(1);
                         }
                     }, 250);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1493,9 +1493,6 @@ window.App = (function () {
                     if (!timer.cooledDown() || self.color === -1) { // nope can't place yet
                         return;
                     }
-                    if (!ls.get("audio_muted")) {
-                        self.audio.cloneNode(false).play();
-                    }
                     self._place(x, y);
                 },
                 _place: function (x, y) {
@@ -1606,6 +1603,9 @@ window.App = (function () {
                     socket.on("ACK", function(data) {
                         switch(data.ackFor) {
                             case "PLACE":
+                                if (!ls.get("audio_muted")) {
+                                    self.audio.cloneNode(false).play();
+                                }
                             case "UNDO":
                                 if (stackHelper.getStacked() === 0)
                                     stackHelper.setPlaceableText(data.ackFor === "PLACE" ? 0 : 1);

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -575,6 +575,10 @@ input[type="text"] {
     background-image: linear-gradient(to right, #aaa 1px, transparent 1px), linear-gradient(to bottom, #aaa 1px, transparent 1px);
 }
 
+.settingToggles > label {
+    display: block;
+}
+
 /*//////////////////////////*\
 | Mobile Styles
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -452,6 +452,14 @@ body:not(.show-placeable-bubble) #placeableInfoBubble {
     color: #fff;
 }
 
+.bubble.orange-bubble {
+    background-color: rgba(255, 115, 0, 0.7);
+}
+
+.bubble.fat-bubble {
+    padding: 16px 24px;
+}
+
 .left {
     position: fixed;
     left: 10px;


### PR DESCRIPTION
This PR brings the following:

1) Don't play 'place' confirmation audio until the pixel is acknowledged by server.
2) Add a "heatmap loading" bubble
3) Local heatmap clearing (allows one to clear the heatmap client-side, must be enabled in settings prior to keybind working)
4) Fix the pixel count being wrong when reloading the page while on cooldown

Some other minor tweaks:
* Exposed heatmap clearing in the `App` object for programmatic access.
* Fixed setting toggle styles to use CSS rather than `br` elements.