### PR TITLE
Fix "undo" always using default board color when database lookup misses

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -290,12 +290,13 @@ public class App {
     public static void putPixel(int x, int y, int color, User user, boolean mod_action, String ip, boolean updateDatabase) {
         if (x < 0 || x >= width || y < 0 || y >= height || (color >= getPalette().size() && !(color == 0xFF || color == -1))) return;
         String userName = user != null ? user.getName() : "<server>";
+        byte lastColor = board[x + y * width];
 
         board[x + y * width] = (byte) color;
         heatmap[x + y * width] = (byte) 0xFF;
         pixelLogger.log(Level.INFO, String.format("%s %d %d %d %s %s", userName, x, y, color, ip, mod_action ? " (mod)" : ""));
         if (updateDatabase) {
-            database.placePixel(x, y, color, user, mod_action);
+            database.placePixel(x, y, color, lastColor, user, mod_action);
         }
     }
 

--- a/src/main/java/space/pxls/data/DAO.java
+++ b/src/main/java/space/pxls/data/DAO.java
@@ -42,6 +42,7 @@ public interface DAO extends Closeable {
             "x INT UNSIGNED NOT NULL," +
             "y INT UNSIGNED NOT NULL," +
             "color TINYINT NOT NULL," +
+            "lastColor TINYINT NOT NULL DEFAULT -1," +
             "who INT UNSIGNED," +
             "secondary_id INT UNSIGNED," + //is previous pixel's id normally, is the id that was changed from for rollback action, is NULL if there's no previous or it was undo of rollback
             "time TIMESTAMP NOT NULL DEFAULT now(6)," +
@@ -57,10 +58,10 @@ public interface DAO extends Closeable {
     int getMostResentId(@Bind("x") int x, @Bind("y") int y);
 
     @SqlUpdate("UPDATE pixels SET most_recent = false WHERE x = :x AND y = :y;" +
-            "INSERT INTO pixels (x, y, color, who, secondary_id, mod_action)" +
-            "VALUES (:x, :y, :color, :who, :second_id, :mod);" +
+            "INSERT INTO pixels (x, y, color, lastColor, who, secondary_id, mod_action)" +
+            "VALUES (:x, :y, :color, :lastColor, :who, :second_id, :mod);" +
             "UPDATE users SET pixel_count = pixel_count + (1 - :mod), pixel_count_alltime = pixel_count_alltime + (1 - :mod) WHERE id = :who")
-    void putPixel(@Bind("x") int x, @Bind("y") int y, @Bind("color") byte color, @Bind("who") int who, @Bind("mod") boolean mod, @Bind("second_id") int second_id);
+    void putPixel(@Bind("x") int x, @Bind("y") int y, @Bind("color") byte color, @Bind("lastColor") byte lastColor, @Bind("who") int who, @Bind("mod") boolean mod, @Bind("second_id") int second_id);
 
     @SqlUpdate("INSERT INTO pixels (x, y, color, who, secondary_id, rollback_action, most_recent)" +
             "SELECT x, y, color, :who, :from_id, true, false FROM pixels AS pp WHERE pp.id = :to_id ORDER BY id DESC LIMIT 1;" +

--- a/src/main/java/space/pxls/data/DBPixelPlacement.java
+++ b/src/main/java/space/pxls/data/DBPixelPlacement.java
@@ -13,6 +13,7 @@ public class DBPixelPlacement {
     public final int x;
     public final int y;
     public final int color;
+    public final int lastColor;
     public final int secondaryId;
     public final long time;
     public final int userId;
@@ -27,11 +28,12 @@ public class DBPixelPlacement {
     public final boolean undoAction;
     public final String userAgent;
 
-    public DBPixelPlacement(int id, int x, int y, int color, int secondaryId, long time, int userId, String username, String login, Role role, long ban_expiry, int pixel_count, int pixel_count_alltime, String ban_reason, boolean banned, boolean undoAction, String userAgent) {
+    public DBPixelPlacement(int id, int x, int y, int color, int lastColor, int secondaryId, long time, int userId, String username, String login, Role role, long ban_expiry, int pixel_count, int pixel_count_alltime, String ban_reason, boolean banned, boolean undoAction, String userAgent) {
         this.id = id;
         this.x = x;
         this.y = y;
         this.color = color;
+        this.lastColor = lastColor;
         this.secondaryId = secondaryId;
         this.time = time;
         this.userId = userId;
@@ -62,6 +64,7 @@ public class DBPixelPlacement {
                     r.getInt("x"),
                     r.getInt("y"),
                     r.getInt("color"),
+                    r.getInt("lastColor"),
                     r.getInt("secondary_id"),
                     time == null ? 0 : time.getTime(),
                     r.getInt("users.id"),

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -79,8 +79,12 @@ public class Database implements Closeable {
     }
 
     public void placePixel(int x, int y, int color, User who, boolean mod_action) {
+        placePixel(x, y, color, -1, who, mod_action);
+    }
+
+    public void placePixel(int x, int y, int color, int lastColor, User who, boolean mod_action) {
         int second_id = getHandle().getMostResentId(x, y);
-        getHandle().putPixel(x, y, (byte) color, who != null ? who.getId() : 0, mod_action, second_id);
+        getHandle().putPixel(x, y, (byte) color, (byte) lastColor, who != null ? who.getId() : 0, mod_action, second_id);
     }
 
     public void updateUserTime(int uid, long seconds) {

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -153,10 +153,10 @@ public class PacketHandler {
             broadcastPixelUpdate(lastPixel.x, lastPixel.y, lastPixel.color);
             ackUndo(user, lastPixel.x, lastPixel.y);
         } else {
-            byte defaultColor = App.getDefaultColor(thisPixel.x, thisPixel.y);
-            App.getDatabase().putUserUndoPixel(thisPixel.x, thisPixel.y, defaultColor, user, thisPixel.id);
-            App.putPixel(thisPixel.x, thisPixel.y, defaultColor, user, false, "(user undo)", false);
-            broadcastPixelUpdate(thisPixel.x, thisPixel.y, defaultColor);
+            int undoColor = thisPixel.lastColor == -1 ? App.getDefaultColor(thisPixel.x, thisPixel.y) : thisPixel.lastColor; //-1 is the default value. In the event that lastPixel doesn't get set for some reason, we default to the board's default color. Otherwise, we use whatever color was under this pixel at the time of place via App.putPixel
+            App.getDatabase().putUserUndoPixel(thisPixel.x, thisPixel.y, undoColor, user, thisPixel.id);
+            App.putPixel(thisPixel.x, thisPixel.y, undoColor, user, false, "(user undo)", false);
+            broadcastPixelUpdate(thisPixel.x, thisPixel.y, undoColor);
             ackUndo(user, thisPixel.x, thisPixel.y);
         }
         sendCooldownData(user);


### PR DESCRIPTION
This modifies the `pixels` column to track a `lastColor` int. Whenever `App.putPixel` is called, it stores the current pixel from the board array before overwriting with the new color. This stored value is placed in the `lastColor` column. This way, when undoing, the correct color is returned even if there's no pixel history.