### PR TITLE
J/K keybinds to cycle through palette

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -62,6 +62,7 @@
                 <p>P to take a snapshot</p>
                 <p>H to toggle heatmap</p>
                 <p>O to clear heatmap (if enabled)</p>
+                <p>J/K to cycle through palette colors</p>
             </div>
             <div>
                 <h1>Template control</h1>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -637,6 +637,22 @@ window.App = (function () {
                             case 76:
                                 self.allowDrag = !self.allowDrag;
                                 break;
+                            case "j":
+                            case 74:
+                                if (place.color < 1) {
+                                    place.switch(place.getPaletteRGB().length - 1);
+                                } else {
+                                    place.switch(place.color - 1);
+                                }
+                                break;
+                            case 75:
+                            case "k":
+                                if (place.color + 1 === place.getPaletteRGB().length) {
+                                    place.switch(0);
+                                } else {
+                                    place.switch(place.color + 1);
+                                }
+                                break;
                         }
                         self.pannedWithKeys = true;
                         self.update();
@@ -1738,7 +1754,10 @@ window.App = (function () {
                 switch: self.switch,
                 setPalette: self.setPalette,
                 getPaletteRGB: self.getPaletteRGB,
-                setAutoReset: self.setAutoReset
+                setAutoReset: self.setAutoReset,
+                get color() {
+                    return self.color;
+                }
             };
         })(),
         // this is the user lookup helper


### PR DESCRIPTION
This pull request enables the front-end functionality of pressing J and K on the keyboard to go left and right on the palette respectively, wrapping to the other side if necessary. The ‘settings’ panel also details this change.