### PR TITLE
Ability to choose the format of snapshots

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -50,12 +50,12 @@
                     <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
                     <label>Heatmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
                     <label>
-                        <select id="downloadImageFormat">
+                        Snapshot (hotkey: p) image format
+                        <select id="snapshotImageFormat">
                             <option value="image/png" selected>PNG</option>
                             <option value="image/jpeg">JPEG</option>
                             <option value="image/webp">WEBP (Chrome only)</option>
                         </select>
-                        Canvas download (hotkey: p) image format
                     </label>
                 </div>
             </div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -43,20 +43,30 @@
             <div>
                 <h1>General settings</h1>
                 <div class="settingToggles">
-                    <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
-                    <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap</label>
-                    <label><input type="checkbox" id="heatmapClearable">Enable heatmap clearing (hotkey: o)</label>
-                    <label><input id="gridtoggle" type="checkbox"/>Turn on grid</label>
-                    <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
-                    <label>Heatmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
-                    <label>
-                        <select id="downloadImageFormat">
-                            <option value="image/png" selected>PNG</option>
-                            <option value="image/jpeg">JPEG</option>
-                            <option value="image/webp">WEBP (Chrome only)</option>
-                        </select>
-                        Canvas download (hotkey: p) image format
-                    </label>
+                    <input id="audiotoggle" type="checkbox"/>
+                    <label for="audiotoggle">Mute sound</label>
+                    
+                    <input id="heatmaptoggle" type="checkbox"/>
+                    <label for="heatmaptoggle">Turn on heatmap</label>
+                    
+                    <input type="checkbox" id="heatmapClearable"/>
+                    <label for="heatmapClearable">Enable heatmap clearing (hotkey: o)</label>
+                    
+                    <input id="gridtoggle" type="checkbox"/>
+                    <label for="gridtoggle">Turn on grid</label>
+                    
+                    <input id="stickyColorToggle" type="checkbox"/>
+                    <label for="stickyColorToggle">Keep color selected</label>
+                    
+                    <label for="heatmap-opacity">Heatmap BG Opacity:</label>
+                    <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"/>
+                    
+                    <select id="downloadImageFormat">
+                        <option value="image/png" selected>PNG</option>
+                        <option value="image/jpeg">JPEG</option>
+                        <option value="image/webp">WEBP (Chrome only)</option>
+                    </select>
+                    <label for="downloadImageFormat">Canvas download (hotkey: p) image format</label>
                 </div>
             </div>
             <div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -49,6 +49,14 @@
                     <label><input id="gridtoggle" type="checkbox"/>Turn on grid</label>
                     <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
                     <label>Heatmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
+                    <label>
+                        <select id="downloadImageFormat">
+                            <option value="image/png" selected>PNG</option>
+                            <option value="image/jpeg">JPEG</option>
+                            <option value="image/webp">WEBP (Chrome only)</option>
+                        </select>
+                        Canvas download (hotkey: p) image format
+                    </label>
                 </div>
             </div>
             <div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -43,30 +43,20 @@
             <div>
                 <h1>General settings</h1>
                 <div class="settingToggles">
-                    <input id="audiotoggle" type="checkbox"/>
-                    <label for="audiotoggle">Mute sound</label>
-                    
-                    <input id="heatmaptoggle" type="checkbox"/>
-                    <label for="heatmaptoggle">Turn on heatmap</label>
-                    
-                    <input type="checkbox" id="heatmapClearable"/>
-                    <label for="heatmapClearable">Enable heatmap clearing (hotkey: o)</label>
-                    
-                    <input id="gridtoggle" type="checkbox"/>
-                    <label for="gridtoggle">Turn on grid</label>
-                    
-                    <input id="stickyColorToggle" type="checkbox"/>
-                    <label for="stickyColorToggle">Keep color selected</label>
-                    
-                    <label for="heatmap-opacity">Heatmap BG Opacity:</label>
-                    <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"/>
-                    
-                    <select id="downloadImageFormat">
-                        <option value="image/png" selected>PNG</option>
-                        <option value="image/jpeg">JPEG</option>
-                        <option value="image/webp">WEBP (Chrome only)</option>
-                    </select>
-                    <label for="downloadImageFormat">Canvas download (hotkey: p) image format</label>
+                    <label><input id="audiotoggle" type="checkbox"/>Mute sound</label>
+                    <label><input id="heatmaptoggle" type="checkbox"/>Turn on heatmap</label>
+                    <label><input type="checkbox" id="heatmapClearable">Enable heatmap clearing (hotkey: o)</label>
+                    <label><input id="gridtoggle" type="checkbox"/>Turn on grid</label>
+                    <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
+                    <label>Heatmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
+                    <label>
+                        <select id="downloadImageFormat">
+                            <option value="image/png" selected>PNG</option>
+                            <option value="image/jpeg">JPEG</option>
+                            <option value="image/webp">WEBP (Chrome only)</option>
+                        </select>
+                        Canvas download (hotkey: p) image format
+                    </label>
                 </div>
             </div>
             <div>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -813,6 +813,11 @@ window.App = (function () {
                     }
                     self.ctx = self.elements.board[0].getContext("2d");
                     self.initInteraction();
+
+                    $("#downloadImageFormat").val(ls.get("downloadImageFormat"));
+                    $("#downloadImageFormat").on("change input", event => {
+                        ls.set("downloadImageFormat", event.target.value);
+                    });
                 },
                 start: function () {
                     $.get("/info", function (data) {
@@ -1082,8 +1087,10 @@ window.App = (function () {
                 },
                 save: function () {
                     var a = document.createElement("a");
-                    a.href = self.elements.board[0].toDataURL("image/png");
-                    a.download = (new Date()).toISOString().replace(/^(\d+-\d+-\d+)T(\d+):(\d+):(\d).*$/,"pxls canvas $1 $2.$3.$4.png");
+                    const format = ls.get("downloadImageFormat");
+
+                    a.href = self.elements.board[0].toDataURL(format, 1);
+                    a.download = (new Date()).toISOString().replace(/^(\d+-\d+-\d+)T(\d+):(\d+):(\d).*$/,`pxls canvas $1 $2.$3.$4.${format.split("/")[1]}`);
                     document.body.appendChild(a);
                     a.click();
                     document.body.removeChild(a);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -814,9 +814,9 @@ window.App = (function () {
                     self.ctx = self.elements.board[0].getContext("2d");
                     self.initInteraction();
 
-                    $("#downloadImageFormat").val(ls.get("downloadImageFormat"));
-                    $("#downloadImageFormat").on("change input", event => {
-                        ls.set("downloadImageFormat", event.target.value);
+                    $("#snapshotImageFormat").val(ls.get("snapshotImageFormat"));
+                    $("#snapshotImageFormat").on("change input", event => {
+                        ls.set("snapshotImageFormat", event.target.value);
                     });
                 },
                 start: function () {
@@ -1087,7 +1087,7 @@ window.App = (function () {
                 },
                 save: function () {
                     var a = document.createElement("a");
-                    const format = ls.get("downloadImageFormat");
+                    const format = ls.get("snapshotImageFormat");
 
                     a.href = self.elements.board[0].toDataURL(format, 1);
                     a.download = (new Date()).toISOString().replace(/^(\d+-\d+-\d+)T(\d+):(\d+):(\d).*$/,`pxls canvas $1 $2.$3.$4.${format.split("/")[1]}`);


### PR DESCRIPTION
This pull request adds a new setting to the settings menu, allowing to choose to have snapshots taken as JPEGs or WEBP (Chrome exclusive) instead of PNG via a dropdown. Snapshots are recorded in full quality in the case of JPEG and WEBP.