### PR TITLE
Allow copying a link to the currently moused-over pixel

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -63,6 +63,7 @@
                 <p>H to toggle heatmap</p>
                 <p>O to clear heatmap (if enabled)</p>
                 <p>J/K to cycle through palette colors</p>
+                <p>C to copy link of moused-over coordinates</p>
             </div>
             <div>
                 <h1>Template control</h1>

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2172,6 +2172,7 @@ window.App = (function () {
                 elements: {
                     coords: $("#coords")
                 },
+                mouseCoords: null,
                 init: function () {
                     self.elements.coords.hide();
                     const _board = board.getRenderBoard()[0];
@@ -2186,14 +2187,22 @@ window.App = (function () {
                     function pointerHandler(evt) {
                         var boardPos = board.fromScreen(evt.clientX, evt.clientY);
 
+                        self.mouseCoords = boardPos;
                         self.elements.coords.text("(" + (boardPos.x | 0) + ", " + (boardPos.y | 0) + ")").fadeIn(200);
                     }
 
                     function touchHandler(evt) {
                         var boardPos = board.fromScreen(evt.changedTouches[0].clientX, evt.changedTouches[0].clientY);
-
+                        
+                        self.mouseCoords = boardPos;
                         self.elements.coords.text("(" + (boardPos.x | 0) + ", " + (boardPos.y | 0) + ")").fadeIn(200);
                     }
+
+                    $(window).keydown(event => {
+                        if ((event.key === "c" || event.key === "C" || event.keyCode === 67) && navigator.clipboard && self.mouseCoords) {
+                            navigator.clipboard.writeText(location.origin + `/#x=${self.mouseCoords.x}&y=${self.mouseCoords.y}`);
+                        }
+                    });
                 }
             };
             return {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2200,7 +2200,7 @@ window.App = (function () {
 
                     $(window).keydown(event => {
                         if ((event.key === "c" || event.key === "C" || event.keyCode === 67) && navigator.clipboard && self.mouseCoords) {
-                            navigator.clipboard.writeText(location.origin + `/#x=${self.mouseCoords.x}&y=${self.mouseCoords.y}`);
+                            navigator.clipboard.writeText(location.origin + `/#x=${Math.floor(self.mouseCoords.x)}&y=${Math.floor(self.mouseCoords.y)}`);
                         }
                     });
                 }


### PR DESCRIPTION
This pull request adds a much-needed functionality: copying links to pixels. It copies a link to the same coordinates seen in the UI (the ones being moused-over at the time) after pressing `C`. This only works on browsers with the [Async Clipboard API](https://github.com/w3c/clipboard-apis/blob/master/explainer.adoc), and will fail silently if that requirement is not met.

Assuming the mouse is over (0, 0) on a test server, pressing C will copy the following to the clipboard:

    http://localhost:4567/#x=0&y=0

Scale, templates, and other options are not copied in this process, and if needed, one can just copy the URL from the address bar.