### PR TITLE
Add capability to provide extra data for lookup

### DIFF
--- a/developer.md
+++ b/developer.md
@@ -61,3 +61,17 @@ App.ls.get('blah'); // returns the object
 App.ls.remove('blah'); // remove the contents of blah
 App.ls.get('blah'); // not defined, returns undefined
 ```
+
+## Lookup Hooks
+
+It is possible to extend the built-in pixel lookup functionality by registering a hook which has an id, user-facing name, and a function which provides the basic lookup information.
+
+```js
+App.lookup.registerHook({
+    id: "rebel_hook",
+    name: "Rebellious Hook",
+    get: data => `Hehehe... the X is ${data.x} and Y is ${data.y}...`,
+});
+```
+
+Your function's return value is an array of or single DOM element, jQuery object, or string.

--- a/developer.md
+++ b/developer.md
@@ -1,51 +1,59 @@
 # Developer Documentation
+
 What this file is for is to document the different features for developers to either use inside of `pxls.js` when doing dev or what is exposed so that other people can write their own userscripts to do cool stuff!
 
 All the things are called via the object, in case of inside of the `pxls.js` tis is `self`, for the outside it is `App`. This documentation will just use the `App` notation.
 
 ## Templating
+
 Templating is already provided via URL parameters, but you can easily modify it via scripts. For that there is `App.updateTemplate()`. It works by passing a template-object as an argument. A full template object looks like the following:
-```
+
+```js
 App.updateTemplate({
-	use: true, // boolean, true/false
-	url: 'https://example.com/image.png', // string, url of image
-	x: 5, // float, x-position of image
-	y: 42, // float, y-position of image
-	width: 7, // float, width of image, if scaling is desired
-	opacity: 0.5, // opacity, 1 is max, 0 is min
+    use: true, // boolean, true/false
+    url: 'https://example.com/image.png', // string, url of image
+    x: 5, // float, x-position of image
+    y: 42, // float, y-position of image
+    width: 7, // float, width of image, if scaling is desired
+    opacity: 0.5, // opacity, 1 is max, 0 is min
 });
 ```
+
 You can omit any keys if you want. For example:
-```
+
+```js
 // initialize the template
 App.updateTemplate({
-	use: true,
-	url: 'https://example.com/image.png',
-	x: 1337,
-	y: 3
+    use: true,
+    url: 'https://example.com/image.png',
+    x: 1337,
+    y: 3
 });
 
 // some code
 
 // hide the template
 App.updateTemplate({
-	opacity: 0
+    opacity: 0
 });
 
 // other code
 
 // show the template
 App.updateTemplate({
-	opacity: 1
+    opacity: 1
 });
 ```
+
 Please note that once you set `use` to `false` it will forget all previously set parameters, so either keep track of an entire template object or, if you want to toggle it on/off, set the opacity to 0 instead.
 
 ## Storage
+
 We also provide powerful storage wrappers for `localStorage` and `sessionStorage`. Both have a fallback to cookies, 99-days or session-cookies, depending on the type of storage. Both handlers are same to be used, here will be stated `App.ls`, which is the localStorage handler. `App.ss` is the respective sessionStorage handler.
 
-It is possible to store any json-ify-able thing.
-```
+It is possible to store anything that can be expressed via JSON.
+
+```js
 App.ls.set('blah', 42); // sets 'blah' to 42
 App.ls.get('blah'); // returns 42
 App.ls.set('blah', {a: 'b'}); // sets an object in 'blah'

--- a/developer.md
+++ b/developer.md
@@ -64,14 +64,17 @@ App.ls.get('blah'); // not defined, returns undefined
 
 ## Lookup Hooks
 
-It is possible to extend the built-in pixel lookup functionality by registering a hook which has an id, user-facing name, and a function which provides the basic lookup information.
+It is possible to extend the built-in pixel lookup functionality by registering a hook which has an id, user-facing name, a function which provides the basic lookup information, and an object mapping CSS rules to their values.
 
 ```js
 App.lookup.registerHook({
     id: "rebel_hook",
     name: "Rebellious Hook",
     get: data => `Hehehe... the X is ${data.x} and Y is ${data.y}...`,
+    css: {
+        color: "yellow",
+    },
 });
 ```
 
-Your function's return value is an array of or single DOM element, jQuery object, or string.
+Your function's return value is can be a jQuery object or a string that will be wrapped in a span element.

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1854,10 +1854,10 @@ window.App = (function () {
                 create: function (data) {
                     self._makeShell(data).find(".content").first().append(function () {
                         if (data) {
-                            $.map(hooks, function (hook) {
+                            return $.map(self.hooks, function (hook) {
                                 return $("<div>").append(
                                     $("<b>").text(hook.name + ": "),
-                                    $("<span>").text(hook.get())
+                                    $("<span>").text(hook.get(data))
                                 ).attr("id", "lookuphook_" + hook.id);
                             });
                         } else {
@@ -1930,7 +1930,7 @@ window.App = (function () {
                     self.registerHook({
                         id: "pixels",
                         name: "Pixels",
-                        get: data => data.pixel_Count,
+                        get: data => data.pixel_count,
                     });
                     self.registerHook({
                         id: "pixels_alltime",

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1957,6 +1957,7 @@ window.App = (function () {
             return {
                 init: self.init,
                 registerHandle: self.registerHandle,
+                registerHook: self.registerHook,
                 runLookup: self.runLookup,
                 clearHandle: self.clearHandle
             };
@@ -2524,6 +2525,11 @@ window.App = (function () {
             normalize: function(obj, dir=true) {
                 return template.normalizeTemplateObj(obj, dir);
             }
+        },
+        lookup: {
+            registerHook: function () {
+                return lookup.registerHook(...arguments);
+            },
         },
         centerBoardOn: function(x, y) {
             board.centerOn(x, y);

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1850,7 +1850,7 @@ window.App = (function () {
                  * @param {Object} hooks.css An object mapping CSS rules to values for the hook value.
                  */
                 registerHook: function (...hooks) {
-                    return self.hooks.push(...$.map(hook, function () {
+                    return self.hooks.push(...$.map(hooks, function (hook) {
                         return {
                             id: hook.id || "hook",
                             name: hook.name || "Hook",

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1863,7 +1863,7 @@ window.App = (function () {
                             return $.map(self.hooks, function (hook) {
                                 return $("<div>").append(
                                     $("<b>").text(hook.name + ": "),
-                                    $("<span>").text(hook.get(data).css(hook.css))
+                                    $("<span>").text(hook.get(data)).css(hook.css)
                                 ).attr("id", "lookuphook_" + hook.id);
                             });
                         } else {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1842,20 +1842,22 @@ window.App = (function () {
                  */
                 hooks: [], 
                 /**
-                 * Registers a hook.
-                 * @param {Object} hook Information about the hook.
-                 * @param {String} hook.id An ID for the hook.
-                 * @param {String} hook.name A user-facing name for the hook.
-                 * @param {Function} hook.get A function that returns the text information shown in the lookup.
-                 * @param {Object} hook.css An object mapping CSS rules to values for the hook value.
+                 * Registers hooks.
+                 * @param {Object} hooks Information about the hook.
+                 * @param {String} hooks.id An ID for the hook.
+                 * @param {String} hooks.name A user-facing name for the hook.
+                 * @param {Function} hooks.get A function that returns the text information shown in the lookup.
+                 * @param {Object} hooks.css An object mapping CSS rules to values for the hook value.
                  */
-                registerHook: function (hook) {
-                    return self.hooks.push({
-                        id: hook.id || "hook",
-                        name: hook.name || "Hook",
-                        get: hook.get || function () {},
-                        css: hook.css || {},
-                    });
+                registerHook: function (...hooks) {
+                    return self.hooks.push(...$.map(hook, function () {
+                        return {
+                            id: hook.id || "hook",
+                            name: hook.name || "Hook",
+                            get: hook.get || function () {},
+                            css: hook.css || {},
+                        };
+                    }));
                 },
                 create: function (data) {
                     self._makeShell(data).find(".content").first().append(function () {
@@ -1918,31 +1920,29 @@ window.App = (function () {
                 },
                 init: function () {
                     // Register default hooks
-                    self.registerHook({
-                        id: "coords",
-                        name: "Coords",
-                        get: data => data.coords,
-                    });
-                    self.registerHook({
-                        id: "username",
-                        name: "Username",
-                        get: data => data.username,
-                    });
-                    self.registerHook({
-                        id: "time",
-                        name: "Time",
-                        get: data => data.time_str,
-                    });
-                    self.registerHook({
-                        id: "pixels",
-                        name: "Pixels",
-                        get: data => data.pixel_count,
-                    });
-                    self.registerHook({
-                        id: "pixels_alltime",
-                        name: "Alltime Pixels",
-                        get: data => data.pixel_count_alltime,
-                    });
+                    self.registerHook(
+                        {
+                            id: "coords",
+                            name: "Coords",
+                            get: data => data.coords,
+                        }, {
+                            id: "username",
+                            name: "Username",
+                            get: data => data.username,
+                        }, {
+                            id: "time",
+                            name: "Time",
+                            get: data => data.time_str,
+                        }, {
+                            id: "pixels",
+                            name: "Pixels",
+                            get: data => data.pixel_count,
+                        }, {
+                            id: "pixels_alltime",
+                            name: "Alltime Pixels",
+                            get: data => data.pixel_count_alltime,
+                        }
+                    );
 
                     self.elements.lookup.hide();
                     self.elements.prompt.hide();

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1859,6 +1859,15 @@ window.App = (function () {
                         };
                     }));
                 },
+                /**
+                 * Unregisters a hook by its ID.
+                 * @param {string} hookId The ID of the hook to unregister.
+                 */
+                unregisterHook: function (hookId) {
+                    return self.hooks = $.grep(self.hooks, function (hook) {
+                        return hook.id !== hookId;
+                    });
+                },
                 create: function (data) {
                     self._makeShell(data).find(".content").first().append(function () {
                         if (data) {
@@ -1964,6 +1973,7 @@ window.App = (function () {
                 init: self.init,
                 registerHandle: self.registerHandle,
                 registerHook: self.registerHook,
+                unregisterHook: self.unregisterHook,
                 runLookup: self.runLookup,
                 clearHandle: self.clearHandle
             };
@@ -2535,6 +2545,9 @@ window.App = (function () {
         lookup: {
             registerHook: function () {
                 return lookup.registerHook(...arguments);
+            },
+            unregisterHook: function () {
+                return lookup.unregisterHook(...arguments);
             },
         },
         centerBoardOn: function(x, y) {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1899,23 +1899,6 @@ window.App = (function () {
                 runLookup(clientX, clientY) {
                     const pos = board.fromScreen(clientX, clientY);
                     $.get("/lookup", {x: Math.floor(pos.x), y: Math.floor(pos.y)}, function (data) {
-                        if (data) {
-                            data.coords = "(" + data.x + ", " + data.y + ")";
-                            var delta = ((new Date()).getTime() - data.time) / 1000;
-                            if (delta > 24*3600) {
-                                data.time_str = (new Date(data.time)).toLocaleString();
-                            } else if (delta < 5) {
-                                data.time_str = 'just now';
-                            } else {
-                                var secs = Math.floor(delta % 60),
-                                    secsStr = secs < 10 ? "0" + secs : secs,
-                                    minutes = Math.floor((delta / 60)) % 60,
-                                    minuteStr = minutes < 10 ? "0" + minutes : minutes,
-                                    hours = Math.floor(delta / 3600),
-                                    hoursStr = hours < 10 ? "0" + hours : hours;
-                                data.time_str = hoursStr+":"+minuteStr+":"+secsStr+" ago";
-                            }
-                        }
                         data = data || false;
                         if (self.handle) {
                             self.handle(data);
@@ -1933,7 +1916,7 @@ window.App = (function () {
                         {
                             id: "coords",
                             name: "Coords",
-                            get: data => data.coords,
+                            get: data => "(" + data.x + ", " + data.y + ")",
                         }, {
                             id: "username",
                             name: "Username",
@@ -1941,7 +1924,22 @@ window.App = (function () {
                         }, {
                             id: "time",
                             name: "Time",
-                            get: data => data.time_str,
+                            get: data => {
+                                var delta = ((new Date()).getTime() - data.time) / 1000;
+                                if (delta > 24 * 3600) {
+                                    return (new Date(data.time)).toLocaleString();
+                                } else if (delta < 5) {
+                                    return 'just now';
+                                } else {
+                                    var secs = Math.floor(delta % 60),
+                                        secsStr = secs < 10 ? "0" + secs : secs,
+                                        minutes = Math.floor((delta / 60)) % 60,
+                                        minuteStr = minutes < 10 ? "0" + minutes : minutes,
+                                        hours = Math.floor(delta / 3600),
+                                        hoursStr = hours < 10 ? "0" + hours : hours;
+                                    return hoursStr + ":" + minuteStr + ":" + secsStr + " ago";
+                                }
+                            }
                         }, {
                             id: "pixels",
                             name: "Pixels",

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1849,7 +1849,7 @@ window.App = (function () {
                  * @param {Function} hook.get
                  */
                 registerHook: function (hook) {
-                    return this.hooks.push(hook);
+                    return self.hooks.push(hook);
                 },
                 create: function (data) {
                     self._makeShell(data).find(".content").first().append(function () {
@@ -1912,27 +1912,27 @@ window.App = (function () {
                 },
                 init: function () {
                     // Register default hooks
-                    this.registerHook({
+                    self.registerHook({
                         id: "coords",
                         name: "Coords",
                         get: data => data.coords,
                     });
-                    this.registerHook({
+                    self.registerHook({
                         id: "username",
                         name: "Username",
                         get: data => data.username,
                     });
-                    this.registerHook({
+                    self.registerHook({
                         id: "time",
                         name: "Time",
                         get: data => data.time_str,
                     });
-                    this.registerHook({
+                    self.registerHook({
                         id: "pixels",
                         name: "Pixels",
                         get: data => data.pixel_Count,
                     });
-                    this.registerHook({
+                    self.registerHook({
                         id: "pixels_alltime",
                         name: "Alltime Pixels",
                         get: data => data.pixel_count_alltime,

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1847,12 +1847,14 @@ window.App = (function () {
                  * @param {String} hook.id
                  * @param {String} hook.name
                  * @param {Function} hook.get
+                 * @param {Object} hook.css
                  */
                 registerHook: function (hook) {
                     return self.hooks.push({
                         id: hook.id || "hook",
                         name: hook.name || "Hook",
                         get: hook.get || function () {},
+                        css: hook.css || {},
                     });
                 },
                 create: function (data) {
@@ -1861,7 +1863,7 @@ window.App = (function () {
                             return $.map(self.hooks, function (hook) {
                                 return $("<div>").append(
                                     $("<b>").text(hook.name + ": "),
-                                    $("<span>").text(hook.get(data))
+                                    $("<span>").text(hook.get(data).css(hook.css))
                                 ).attr("id", "lookuphook_" + hook.id);
                             });
                         } else {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1849,7 +1849,11 @@ window.App = (function () {
                  * @param {Function} hook.get
                  */
                 registerHook: function (hook) {
-                    return self.hooks.push(hook);
+                    return self.hooks.push({
+                        id: hook.id || "hook",
+                        name: hook.name || "Hook",
+                        get: hook.get || function () {},
+                    });
                 },
                 create: function (data) {
                     self._makeShell(data).find(".content").first().append(function () {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1837,21 +1837,33 @@ window.App = (function () {
                         })
                     ).fadeIn(200);
                 },
+                /**
+                 * All lookup hooks.
+                 */
+                hooks: [], 
+                /**
+                 * Registers a hook.
+                 * @param {Object} hook
+                 * @param {String} hook.id
+                 * @param {String} hook.name
+                 * @param {Function} hook.get
+                 */
+                registerHook: function (hook) {
+                    return this.hooks.push(hook);
+                },
                 create: function (data) {
-                    self._makeShell(data).find(".content").first().append(
-                        data ? $.map([
-                            ["Coords", "coords"],
-                            ["Username", "username"],
-                            ["Time", "time_str"],
-                            ["Total Pixels", "pixel_count"],
-                            ["Alltime Pixels", "pixel_count_alltime"]
-                        ], function (o) {
-                            return $("<div>").append(
-                                $("<b>").text(o[0]+": "),
-                                $("<span>").text(data[o[1]])
-                            );
-                        }) : $("<p>").text("This pixel is background (was not placed by a user).")
-                    );
+                    self._makeShell(data).find(".content").first().append(function () {
+                        if (data) {
+                            $.map(hooks, function (hook) {
+                                return $("<div>").append(
+                                    $("<b>").text(hook.name + ": "),
+                                    $("<span>").text(hook.get())
+                                ).attr("id", "lookuphook_" + hook.id);
+                            });
+                        } else {
+                            return $("<p>").text("This pixel is background (was not placed by a user).");
+                        }
+                    });
                     self.elements.lookup.fadeIn(200);
                 },
                 _makeShell: function(data) {
@@ -1899,6 +1911,33 @@ window.App = (function () {
                     });
                 },
                 init: function () {
+                    // Register default hooks
+                    this.registerHook({
+                        id: "coords",
+                        name: "Coords",
+                        get: data => data.coords,
+                    });
+                    this.registerHook({
+                        id: "username",
+                        name: "Username",
+                        get: data => data.username,
+                    });
+                    this.registerHook({
+                        id: "time",
+                        name: "Time",
+                        get: data => data.time_str,
+                    });
+                    this.registerHook({
+                        id: "pixels",
+                        name: "Pixels",
+                        get: data => data.pixel_Count,
+                    });
+                    this.registerHook({
+                        id: "pixels_alltime",
+                        name: "Alltime Pixels",
+                        get: data => data.pixel_count_alltime,
+                    });
+
                     self.elements.lookup.hide();
                     self.elements.prompt.hide();
                     board.getRenderBoard().on("click", function (evt) {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1873,9 +1873,11 @@ window.App = (function () {
                         if (data) {
                             return $.map(self.hooks, function (hook) {
                                 const get = hook.get(data);
+                                const value = typeof get === "object" ? get : $("<span>").text(get);
+
                                 return $("<div>").append(
                                     $("<b>").text(hook.name + ": "),
-                                    (typeof get === "string" ? $("<span>").text(get) : get).css(hook.css)
+                                    value.css(hook.css)
                                 ).attr("id", "lookuphook_" + hook.id);
                             });
                         } else {
@@ -1917,7 +1919,7 @@ window.App = (function () {
                         {
                             id: "coords",
                             name: "Coords",
-                            get: data => "(" + data.x + ", " + data.y + ")",
+                            get: data => $("<a>").text("(" + data.x + ", " + data.y + ")").attr("href", location.origin + `/#x=${data.x}&y=${data.y}`),
                         }, {
                             id: "username",
                             name: "Username",

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1919,7 +1919,7 @@ window.App = (function () {
                         {
                             id: "coords",
                             name: "Coords",
-                            get: data => $("<a>").text("(" + data.x + ", " + data.y + ")").attr("href", location.origin + `/#x=${data.x}&y=${data.y}`),
+                            get: data => $("<a>").text("(" + data.x + ", " + data.y + ")").attr("href", getLinkToCoords(data.x, data.y)),
                         }, {
                             id: "username",
                             name: "Username",
@@ -2264,13 +2264,22 @@ window.App = (function () {
 
                     $(window).keydown(event => {
                         if ((event.key === "c" || event.key === "C" || event.keyCode === 67) && navigator.clipboard && self.mouseCoords) {
-                            navigator.clipboard.writeText(location.origin + `/#x=${Math.floor(self.mouseCoords.x)}&y=${Math.floor(self.mouseCoords.y)}`);
+                            navigator.clipboard.writeText(self.getLinkToCoords(self.mouseCoords.x, self.mouseCoords.y));
                         }
                     });
+                },
+                /**
+                 * Returns a link to the website at a specific position.
+                 * @param {number} x The X coordinate for the link to have.
+                 * @param {number} y The Y coordinate for the link to have.
+                 */
+                getLinkToCoords: (x = 0, y = 0) => {
+                    return `${location.origin}/#x=${Math.floor(x)}&y=${Math.floor(y)}`;
                 }
             };
             return {
-                init: self.init
+                init: self.init,
+                getLinkToCoords: self.getLinkToCoords,
             };
         })(),
         // this holds user stuff / info

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2274,7 +2274,7 @@ window.App = (function () {
                  * @param {number} y The Y coordinate for the link to have.
                  */
                 getLinkToCoords: (x = 0, y = 0) => {
-                    return `${location.origin}/#x=${Math.floor(x)}&y=${Math.floor(y)}`;
+                    return `${location.origin}/#x=${Math.floor(x)}&y=${Math.floor(y)}&scale=20`;
                 }
             };
             return {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1843,11 +1843,11 @@ window.App = (function () {
                 hooks: [], 
                 /**
                  * Registers a hook.
-                 * @param {Object} hook
-                 * @param {String} hook.id
-                 * @param {String} hook.name
-                 * @param {Function} hook.get
-                 * @param {Object} hook.css
+                 * @param {Object} hook Information about the hook.
+                 * @param {String} hook.id An ID for the hook.
+                 * @param {String} hook.name A user-facing name for the hook.
+                 * @param {Function} hook.get A function that returns the text information shown in the lookup.
+                 * @param {Object} hook.css An object mapping CSS rules to values for the hook value.
                  */
                 registerHook: function (hook) {
                     return self.hooks.push({

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1872,9 +1872,10 @@ window.App = (function () {
                     self._makeShell(data).find(".content").first().append(function () {
                         if (data) {
                             return $.map(self.hooks, function (hook) {
+                                const get = hook.get(data);
                                 return $("<div>").append(
                                     $("<b>").text(hook.name + ": "),
-                                    $("<span>").text(hook.get(data)).css(hook.css)
+                                    (typeof get === "string" ? $("<span>").text(get) : get).css(hook.css)
                                 ).attr("id", "lookuphook_" + hook.id);
                             });
                         } else {


### PR DESCRIPTION
This pull request changes the system in which lookup data is provided, allowing developers to add their own data to it, along with making the existing data more capable in the future. The developer guide has been updated to demonstrate how this works, and you can use it in a userscript with `App.lookup.registerHook(hook);`