### PR TITLE
Add "Move Template" button on lookups

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1864,7 +1864,13 @@ window.App = (function () {
                         : ""),
                         $("<div>").addClass("button").css("float", "right").text("Close").click(function () {
                             self.elements.lookup.fadeOut(200);
-                        })
+                        }),
+                        (data ? $("<div>").addClass("button").css("float", "right").text("Move Template").click(function () {
+                            template.queueUpdate({
+                                ox: data.x,
+                                oy: data.y,
+                            });
+                        }) : "")
                     );
                 },
                 runLookup(clientX, clientY) {

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1504,6 +1504,9 @@ window.App = (function () {
                             self.elements.template.css("pointer-events", "none").data("dragging", false);
                         }
                     });
+                },
+                getOptions: function () {
+                    return self.options;
                 }
             };
             return {
@@ -1511,7 +1514,8 @@ window.App = (function () {
                 update: self._update,
                 draw: self.draw,
                 init: self.init,
-                queueUpdate: self.queueUpdate
+                queueUpdate: self.queueUpdate,
+                getOptions: self.getOptions,
             };
         })(),
         // here all the grid stuff happens
@@ -1865,7 +1869,7 @@ window.App = (function () {
                         $("<div>").addClass("button").css("float", "right").text("Close").click(function () {
                             self.elements.lookup.fadeOut(200);
                         }),
-                        (data ? $("<div>").addClass("button").css("float", "right").text("Move Template Here").click(function () {
+                        (data && template.getOptions().use ? $("<div>").addClass("button").css("float", "right").text("Move Template Here").click(function () {
                             template.queueUpdate({
                                 ox: data.x,
                                 oy: data.y,

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1865,7 +1865,7 @@ window.App = (function () {
                         $("<div>").addClass("button").css("float", "right").text("Close").click(function () {
                             self.elements.lookup.fadeOut(200);
                         }),
-                        (data ? $("<div>").addClass("button").css("float", "right").text("Move Template").click(function () {
+                        (data ? $("<div>").addClass("button").css("float", "right").text("Move Template Here").click(function () {
                             template.queueUpdate({
                                 ox: data.x,
                                 oy: data.y,

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -108,7 +108,7 @@ a, a:hover, a:visited, a:active {
 .button {
     cursor: pointer;
     margin-top: 6px;
-    margin-right: 6px;
+    margin-right: 4.5px;
     display: inline-block;
     font-size: 12px;
     border: 1px solid #ccc;


### PR DESCRIPTION
This allows for managing template positions on mobile without having to use a keyboard or edit the URL parameters.

![Example of Move Template button](https://user-images.githubusercontent.com/24855774/43324725-dc54d802-9182-11e8-8993-315841c564a5.png)
