### PR TITLE
Add GitHub links to info

### DIFF
--- a/resources/public/info.html
+++ b/resources/public/info.html
@@ -23,10 +23,10 @@
 	<a href="https://twitter.com/pxls_space" target="_blank">Twitter</a>
 	<a href="https://facebook.com/pxls.space/" target="_blank">Facebook</a>
 	<a href="https://pxls-space.tumblr.com/" target="_blank">Tumblr</a>
-	<a href="https://vk.com/pxls.official" target="_blank">VK</a>
+    <a href="https://vk.com/pxls.official" target="_blank">VK</a>
 	<a href="https://play.google.com/store/apps/details?id=space.pxls.android" target="_blank">Android app</a>
-    <a href="https://github.com/xSke/Pxls" target="_blank">GitHub</a>
-    <a href="https://github.com/xSke/PxlsApp" target="_blank">GitHub (App)</a>
+	<a href="https://github.com/xSke/Pxls" target="_blank">GitHub</a>
+	<a href="https://github.com/xSke/PxlsApp" target="_blank">GitHub (App)</a>
 	<br>
 	<a href="https://combahton.net/" target="_blank">Sponsored by combahton.net</a>
 	<br>

--- a/resources/public/info.html
+++ b/resources/public/info.html
@@ -25,6 +25,8 @@
 	<a href="https://pxls-space.tumblr.com/" target="_blank">Tumblr</a>
 	<a href="https://vk.com/pxls.official" target="_blank">VK</a>
 	<a href="https://play.google.com/store/apps/details?id=space.pxls.android" target="_blank">Android app</a>
+    <a href="https://github.com/xSke/Pxls" target="_blank">GitHub</a>
+    <a href="https://github.com/xSke/PxlsApp" target="_blank">GitHub (App)</a>
 	<br>
 	<a href="https://combahton.net/" target="_blank">Sponsored by combahton.net</a>
 	<br>


### PR DESCRIPTION
This PR adds two GitHub links (one to the main repository, and one the app) to the information box.