### PR TITLE
Fix a typo preventing lookup from working

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1929,7 +1929,7 @@ window.App = (function () {
                         {
                             id: "coords",
                             name: "Coords",
-                            get: data => $("<a>").text("(" + data.x + ", " + data.y + ")").attr("href", getLinkToCoords(data.x, data.y)),
+                            get: data => $("<a>").text("(" + data.x + ", " + data.y + ")").attr("href", coords.getLinkToCoords(data.x, data.y)),
                         }, {
                             id: "username",
                             name: "Username",


### PR DESCRIPTION
A typo that was not caught by me in #111 has been merged, so this pull request fixes it.