### PR TITLE
Add timestamp to hover text for Time lookup hook

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1938,11 +1938,16 @@ window.App = (function () {
                             id: "time",
                             name: "Time",
                             get: data => {
-                                var delta = ((new Date()).getTime() - data.time) / 1000;
+                                const delta = ((new Date()).getTime() - data.time) / 1000;
+                                const stamp = (new Date(data.time)).toLocaleString();
+
+                                const span = $("<span>");
+                                span.attr("title", stamp);
+
                                 if (delta > 24 * 3600) {
-                                    return (new Date(data.time)).toLocaleString();
+                                    return span.text(stamp);
                                 } else if (delta < 5) {
-                                    return 'just now';
+                                    return span.text("just now");
                                 } else {
                                     var secs = Math.floor(delta % 60),
                                         secsStr = secs < 10 ? "0" + secs : secs,
@@ -1950,7 +1955,7 @@ window.App = (function () {
                                         minuteStr = minutes < 10 ? "0" + minutes : minutes,
                                         hours = Math.floor(delta / 3600),
                                         hoursStr = hours < 10 ? "0" + hours : hours;
-                                    return hoursStr + ":" + minuteStr + ":" + secsStr + " ago";
+                                    return span.text(hoursStr + ":" + minuteStr + ":" + secsStr + " ago");
                                 }
                             }
                         }, {


### PR DESCRIPTION
With this pull request, the Time lookup hook can be hovered over to show the timestamp, regardless of whether it has the timestamp already, `just now`, or `XXX ago`.

![Hovering over Time lookup hook](https://user-images.githubusercontent.com/24855774/43416136-78198a7e-9405-11e8-94a3-a69c9bb33518.png)
