### PR TITLE
Convert admin lookup handler to hooks

### DIFF
--- a/resources/public/admin/admin.css
+++ b/resources/public/admin/admin.css
@@ -2,6 +2,11 @@
 | Admin Box
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
+pre {
+    display: inline;
+    white-space: pre-wrap;
+}
+
 .admin {
     position: absolute;
     top: 40vh;

--- a/resources/public/admin/admin.css
+++ b/resources/public/admin/admin.css
@@ -2,11 +2,6 @@
 | Admin Box
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/
 
-pre {
-    display: inline;
-    white-space: pre-wrap;
-}
-
 .admin {
     position: absolute;
     top: 40vh;

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -297,54 +297,6 @@
                 elements: {
                     lookup: $("#lookup")
                 },
-                create: function (data) {
-                    if (data) {
-                        data.coords = "(" + data.x + ", " + data.y + ")";
-                        data.time = (new Date(data.time)).toLocaleString();
-                        self.elements.lookup.empty().append(
-                            $("<div>").addClass("content").append(
-                                $.map([
-                                    ["Coords", "coords"],
-                                    ["Username", "username"],
-                                    ["Login", "login"],
-                                    ["Time", "time_str"],
-                                    ["Total Pixels", "pixel_count"],
-                                    ["Alltime Pixels", "pixel_count_alltime"],
-                                    ["User-Agent", "userAgent"]
-                                ], function (o) {
-                                    return $("<div>").append(
-                                        $("<b>").text(o[0]+": "),
-                                        $("<span>").text(data[o[1]])
-                                    );
-                                }),
-                                sendAlert(data.username)
-                            ),
-                            $("<div>").append(
-                                genButton("Ban (24h)").click(function () {
-                                    
-                                }),
-                                genButton("More...").click(function () {
-                                    
-                                }),
-                                genButton("Close").click(function () {
-                                    self.elements.lookup.fadeOut(200);
-                                })
-                            )
-                        ).fadeIn(200);
-                    } else {
-                        self.elements.lookup.empty().append(
-                            $("<div>").append(
-                                $("<p>").text("This pixel is virgin.")
-                            )
-                        ).append(
-                            $("<div>").append(
-                                genButton("Close").click(function() {
-                                    self.elements.lookup.fadeOut(200)
-                                })
-                            )
-                        ).fadeIn(200);
-                    }
-                },
                 /**
                  * Register hooks for admin-specific lookups.
                  */

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -321,13 +321,10 @@
                             ),
                             $("<div>").append(
                                 genButton("Ban (24h)").click(function () {
-                                    ban.ban_24h(data.username, function () {
-                                        self.elements.lookup.fadeOut(200);
-                                    });
+                                    
                                 }),
                                 genButton("More...").click(function () {
-                                    checkUser.check(data.username);
-                                    self.elements.lookup.fadeOut(200);
+                                    
                                 }),
                                 genButton("Close").click(function () {
                                     self.elements.lookup.fadeOut(200);
@@ -349,10 +346,36 @@
                     }
                 },
                 init: function () {
-                    admin.lookup.registerHandle(self.create);
+                    App.lookup.registerHook({
+                        id: "login",
+                        name: "Login",
+                        get: data => $("<pre>").text(data.login),
+                    }, {
+                        id: "user_agent",
+                        name: "User Agent",
+                        get: data => $("<pre>").text(data.userAgent),
+                    }, {
+                        id: "day_ban",
+                        name: "Ban (24h)",
+                        get: data => $("<button>").text("Dab on this rulebreaker lmao").click(() => {
+                            ban.ban_24h(data.username, function () {
+                                self.elements.lookup.fadeOut(200);
+                            });
+                        }),
+                    }, {
+                        id: "more",
+                        name: "More",
+                        get: data => $("<button>").text(":)").click(() => {
+                            checkUser.check(data.username);
+                            self.elements.lookup.fadeOut(200);
+                        }),
+                    });
                 },
                 deinit: function () {
-                    admin.lookup.clearHandle(self.create);
+                    App.lookup.unregisterHook("login");
+                    App.lookup.unregisterHook("user_agent");
+                    App.lookup.unregisterHook("day_ban");
+                    App.lookup.unregisterHook("more");
                 }
             };
             return {

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -345,6 +345,9 @@
                         ).fadeIn(200);
                     }
                 },
+                /**
+                 * Register hooks for admin-specific lookups.
+                 */
                 init: function () {
                     App.lookup.registerHook({
                         id: "login",
@@ -371,6 +374,9 @@
                         }),
                     });
                 },
+                /**
+                 * Unregister hooks for admin-specific lookups.
+                 */
                 deinit: function () {
                     App.lookup.unregisterHook("login");
                     App.lookup.unregisterHook("user_agent");

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -301,11 +301,11 @@
                 init: function () {
                     App.lookup.registerHook({
                         id: "login",
-                        name: "Login",
+						name: "Login",
 						get: data => $("<code>").text(data.login),
                     }, {
                         id: "user_agent",
-                        name: "User Agent",
+						name: "User Agent",
 						get: data => $("<code>").text(data.userAgent),
                     }, {
 						id: "alert",

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -310,6 +310,10 @@
                         name: "User Agent",
                         get: data => $("<pre>").text(data.userAgent),
                     }, {
+						id: "alert",
+						name: "Send Alert",
+						get: data => sendAlert(data.username),
+					}, {
                         id: "day_ban",
                         name: "Ban (24h)",
                         get: data => genButton("🔨").click(() => {

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -302,11 +302,11 @@
                     App.lookup.registerHook({
                         id: "login",
                         name: "Login",
-                        get: data => $("<pre>").text(data.login),
+						get: data => $("<code>").text(data.login),
                     }, {
                         id: "user_agent",
                         name: "User Agent",
-                        get: data => $("<pre>").text(data.userAgent),
+						get: data => $("<code>").text(data.userAgent),
                     }, {
 						id: "alert",
 						name: "Send Alert",

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -357,7 +357,7 @@
                     }, {
                         id: "day_ban",
                         name: "Ban (24h)",
-                        get: data => $("<button>").text("Dab on this rulebreaker lmao").click(() => {
+                        get: data => genButton("🔨").click(() => {
                             ban.ban_24h(data.username, function () {
                                 self.elements.lookup.fadeOut(200);
                             });
@@ -365,7 +365,7 @@
                     }, {
                         id: "more",
                         name: "More",
-                        get: data => $("<button>").text(":)").click(() => {
+                        get: data => genButton("ℹ️").click(() => {
                             checkUser.check(data.username);
                             self.elements.lookup.fadeOut(200);
                         }),

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -312,20 +312,19 @@
 						name: "Send Alert",
 						get: data => sendAlert(data.username),
 					}, {
-                        id: "day_ban",
-                        name: "Ban (24h)",
-                        get: data => genButton("🔨").click(() => {
-                            ban.ban_24h(data.username, function () {
-                                self.elements.lookup.fadeOut(200);
-                            });
-                        }),
-                    }, {
-                        id: "more",
-                        name: "More",
-                        get: data => genButton("ℹ️").click(() => {
-                            checkUser.check(data.username);
-                            self.elements.lookup.fadeOut(200);
-                        }),
+                        id: "admin_actions",
+                        name: "Mod Actions",
+                        get: data => $("<span>").append(
+							genButton("Ban (24h)").click(() => {
+								ban.ban_24h(data.username, function () {
+									self.elements.lookup.fadeOut(200);
+								});
+							}),
+							genButton("More...").click(() => {
+								checkUser.check(data.username);
+								self.elements.lookup.fadeOut(200);
+							}),
+						),
                     });
                 },
                 /**

--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -10,19 +10,17 @@
             }).addClass("button").text(s);
         },
         sendAlert = function(username) {
-            return $("<div>").append(
-                $("<input>").attr("placeholder", "Send alert...").keydown(function (evt) {
-                    if (evt.which === 13) {
-                        admin.socket.send({
-                            type: "admin_message",
-                            username: username,
-                            message: this.value
-                        });
-                        this.value = "";
-                    }
-                    evt.stopPropagation();
-                })
-            )
+            return $("<input>").attr("placeholder", "Send alert...").keydown(function (evt) {
+				if (evt.which === 13) {
+					admin.socket.send({
+						type: "admin_message",
+						username: username,
+						message: this.value
+					});
+					this.value = "";
+				}
+				evt.stopPropagation();
+			});
         },
         ban = (function() {
             var self = {
@@ -178,7 +176,7 @@
                                 $("<span>").text(o[1])
                             );
                         }),
-                        sendAlert(data.username),
+                        $("<div>").append(sendAlert(data.username)),
                         $("<div>").append(
                             genButton("Ban (24h)").click(function () {
                                 ban.ban_24h(data.username, function () {

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -147,10 +147,6 @@ a, a:hover, a:visited, a:active {
     background: #ce4747;
 }
 
-.content .button {
-    font-size: 8px;
-}
-
 .content {
     margin-bottom: 10px;
 }

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -147,6 +147,14 @@ a, a:hover, a:visited, a:active {
     background: #ce4747;
 }
 
+.content .button {
+    font-size: 8px;
+}
+
+.content {
+    margin-bottom: 10px;
+}
+
 /*//////////////////////////*\
 | Info / Template Drawer
 \*\\\\\\\\\\\\\\\\\\\\\\\\\\*/


### PR DESCRIPTION
This pull request removes the admin lookup handler which has code mostly duplicated from the default one, and instead adds in hooks registered and unregistered alongside other admin features. This allows admins to be able to use the hooks feature and gets rid of the need to support two different lookup handlers at once.