### PR TITLE
Fix time_str rename on modtools

### DIFF
--- a/resources/public/admin/admin.js
+++ b/resources/public/admin/admin.js
@@ -307,7 +307,7 @@
                                     ["Coords", "coords"],
                                     ["Username", "username"],
                                     ["Login", "login"],
-                                    ["Time", "time_str"],
+                                    ["Time", "time"],
                                     ["Total Pixels", "pixel_count"],
                                     ["Alltime Pixels", "pixel_count_alltime"],
                                     ["User-Agent", "userAgent"]


### PR DESCRIPTION
Fixes the `time` row being blank for mods+