### PR TITLE
Allow trial moderators to bypass ratelimits

### DIFF
--- a/src/main/java/space/pxls/util/RateLimitingHandler.java
+++ b/src/main/java/space/pxls/util/RateLimitingHandler.java
@@ -31,7 +31,7 @@ public class RateLimitingHandler implements HttpHandler {
         Cookie header = exchange.getRequestCookies().get("pxls-token");
         if (header != null) {
             User user = App.getUserManager().getByToken(header.getValue());
-            if (user != null && user.getRole().greaterEqual(Role.MODERATOR)) {
+            if (user != null && user.getRole().greaterEqual(Role.TRIALMOD)) {
                 next.handleRequest(exchange);
                 return;
             }


### PR DESCRIPTION
This PR adds the ability for trial moderators to bypass global ratelimits.