### PR TITLE
Don't increase cooldown if the user owns the overwritten pixel

### DIFF
--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -71,6 +71,7 @@ undo {
   cooldown: 15m
 }
 
+selfPixelTimeIncrease: true
 
 // System host, used for various things
 host: ""

--- a/src/main/java/space/pxls/data/DAO.java
+++ b/src/main/java/space/pxls/data/DAO.java
@@ -173,7 +173,7 @@ public interface DAO extends Closeable {
     boolean didPixelChange(@Bind("x") int x, @Bind("y") int y);
 
     @SqlQuery("SELECT EXISTS(SELECT 1 FROM pixels WHERE x = :x AND y = :y AND who <> :who AND most_recent)")
-    boolean shoudPixelTimeIncrease(@Bind("x") int x, @Bind("y") int y, @Bind("who") int who);
+    boolean shouldPixelTimeIncrease(@Bind("x") int x, @Bind("y") int y, @Bind("who") int who);
 
     @SqlUpdate("CREATE TABLE IF NOT EXISTS sessions ("+
             "id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,"+

--- a/src/main/java/space/pxls/data/DAO.java
+++ b/src/main/java/space/pxls/data/DAO.java
@@ -172,6 +172,9 @@ public interface DAO extends Closeable {
     @SqlQuery("SELECT EXISTS(SELECT 1 FROM pixels WHERE x = :x AND y = :y AND most_recent)")
     boolean didPixelChange(@Bind("x") int x, @Bind("y") int y);
 
+    @SqlQuery("SELECT EXISTS(SELECT 1 FROM pixels WHERE x = :x AND y = :y AND who <> :who AND most_recent)")
+    boolean shoudPixelTimeIncrease(@Bind("x") int x, @Bind("y") int y, @Bind("who") int who);
+
     @SqlUpdate("CREATE TABLE IF NOT EXISTS sessions ("+
             "id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,"+
             "who INT UNSIGNED NOT NULL,"+

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -282,6 +282,10 @@ public class Database implements Closeable {
         return getHandle().didPixelChange(x, y);
     }
 
+    public boolean shoudPixelTimeIncrease(int x, int y, int who) {
+        return getHandle().shoudPixelTimeIncrease(x, y, who);
+    }
+
     public void adminLog(String message, int uid) {
         getHandle().adminLog(message, uid);
     }

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -282,8 +282,11 @@ public class Database implements Closeable {
         return getHandle().didPixelChange(x, y);
     }
 
-    public boolean shoudPixelTimeIncrease(int x, int y, int who) {
-        return getHandle().shoudPixelTimeIncrease(x, y, who);
+    public boolean shouldPixelTimeIncrease(int x, int y, int who) {
+        boolean selfPixelTimeIncrease = App.getConfig().getBoolean("selfPixelTimeIncrease");
+        boolean fromDatabase = getHandle().shouldPixelTimeIncrease(x, y, who);
+        System.out.printf("first: %s, second: %s%n", selfPixelTimeIncrease, fromDatabase);
+        return App.getConfig().getBoolean("selfPixelTimeIncrease") ? didPixelChange(x, y) : getHandle().shouldPixelTimeIncrease(x, y, who);
     }
 
     public void adminLog(String message, int uid) {

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -283,9 +283,6 @@ public class Database implements Closeable {
     }
 
     public boolean shouldPixelTimeIncrease(int x, int y, int who) {
-        boolean selfPixelTimeIncrease = App.getConfig().getBoolean("selfPixelTimeIncrease");
-        boolean fromDatabase = getHandle().shouldPixelTimeIncrease(x, y, who);
-        System.out.printf("first: %s, second: %s%n", selfPixelTimeIncrease, fromDatabase);
         return App.getConfig().getBoolean("selfPixelTimeIncrease") ? didPixelChange(x, y) : getHandle().shouldPixelTimeIncrease(x, y, who);
     }
 

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -213,7 +213,7 @@ public class PacketHandler {
                 }*/
                 if (canPlace) {
                     int seconds = getCooldown();
-                    if (c_old != 0xFF && c_old != -1 && App.getDatabase().didPixelChange(cp.getX(), cp.getY())) {
+                    if (c_old != 0xFF && c_old != -1 && App.getDatabase().shoudPixelTimeIncrease(cp.getX(), cp.getY(), user.getId())) {
                         seconds = (int)Math.round(seconds * 1.6);
                     }
                     if (user.isShadowBanned()) {

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -213,7 +213,7 @@ public class PacketHandler {
                 }*/
                 if (canPlace) {
                     int seconds = getCooldown();
-                    if (c_old != 0xFF && c_old != -1 && App.getDatabase().shoudPixelTimeIncrease(cp.getX(), cp.getY(), user.getId())) {
+                    if (c_old != 0xFF && c_old != -1 && App.getDatabase().shouldPixelTimeIncrease(cp.getX(), cp.getY(), user.getId())) {
                         seconds = (int)Math.round(seconds * 1.6);
                     }
                     if (user.isShadowBanned()) {


### PR DESCRIPTION
This PR makes it so that if a user replaces their own pixel, the cooldown will not increase. Replacing someone else's pixel will still increase the cooldown by the current 1.6x