### PR TITLE
Add option to toggle monospace font in lookups

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -48,6 +48,7 @@
                     <label><input type="checkbox" id="heatmapClearable">Enable heatmap clearing (hotkey: o)</label>
                     <label><input id="gridtoggle" type="checkbox"/>Turn on grid</label>
                     <label><input id="stickyColorToggle" type="checkbox"/>Keep color selected</label>
+                    <label><input id="monospaceToggle" type="checkbox"/>Toggle monospace font for lookups</label>
                     <label>Heatmap BG Opacity: <input type="range" min="0" max="1" step="0.01" id="heatmap-opacity"></label>
                     <label>
                         Snapshot (hotkey: p) image format

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2074,6 +2074,11 @@ window.App = (function () {
                     $("#stickyColorToggle").change(function() {
                         place.setAutoReset(!this.checked);
                     });
+
+                    $("#monospaceToggle").change(function() {
+                        ls.set("monospace_lookup", this.checked);
+                        $("code").css({ "font-family": this.checked ? "monospace" : "inherit" })
+                    });
                 }
             };
             return {
@@ -2126,6 +2131,11 @@ window.App = (function () {
                 init: function() {
                     self._initStack();
                     self._initAudio();
+                    if (typeof ls.get("monospace_lookup") === undefined) {
+                        $("#monospaceToggle").checked = true
+                    }
+                    var useMonospace = ls.get("monospace_lookup") === true
+                    $("code").css({ "font-family": useMonospace ? "monospace" : "inherited" });
                 },
                 _initStack: function() {
                     socket.on("pixels", function(data) {


### PR DESCRIPTION
This PR adds a checkbox to toggle the use of the monospace font on lookups.

![screen shot 2018-08-17 at 10 33 28 pm](https://user-images.githubusercontent.com/19217244/44296165-abaa4d80-a26d-11e8-99dd-3127aa718d9b.png)
