### PR TITLE
Keep track of who's been reported on the reports table

### DIFF
--- a/src/main/java/space/pxls/data/DAO.java
+++ b/src/main/java/space/pxls/data/DAO.java
@@ -20,8 +20,8 @@ public interface DAO extends Closeable {
             "time INT(10) UNSIGNED)")
     void createReportsTable();
 
-    @SqlUpdate("INSERT INTO reports (who, pixel_id, x, y, message, time) VALUES (:who, :pixel_id, :x, :y, :message, UNIX_TIMESTAMP())")
-    void addReport(@Bind("who") int who, @Bind("pixel_id") int pixel_id, @Bind("x") int x, @Bind("y") int y, @Bind("message") String message);
+    @SqlUpdate("INSERT INTO reports (who, reported, pixel_id, x, y, message, time) VALUES (:who, :reported, :pixel_id, :x, :y, :message, UNIX_TIMESTAMP())")
+    void addReport(@Bind("who") int reporter, @Bind("reported") int reported, @Bind("pixel_id") int pixel_id, @Bind("x") int x, @Bind("y") int y, @Bind("message") String message);
 
     @SqlUpdate("INSERT INTO reports (who, pixel_id, x, y, message, reported, time) VALUES (0, 0, 0, 0, :message, :reported, UNIX_TIMESTAMP())")
     void addServerReport(@Bind("message") String message, @Bind("reported") int reported);

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -294,8 +294,8 @@ public class Database implements Closeable {
         getHandle().adminLogServer(message);
     }
 
-    public void addReport(int who, int pixel_id, int x, int y, String message) {
-        getHandle().addReport(who, pixel_id, x, y, message);
+    public void addReport(int whosReporting, int userReported, int pixel_id, int x, int y, String message) {
+        getHandle().addReport(whosReporting, userReported, pixel_id, x, y, message);
     }
 
     public void addServerReport(String message, int reported) {

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -558,7 +558,7 @@ public class WebHandler {
             exchange.endExchange();
             return;
         }
-        App.getDatabase().addReport(user.getId(), id, x, y, msgq.getValue());
+        App.getDatabase().addReport(user.getId(), pxl.userId, id, x, y, msgq.getValue());
         exchange.setStatusCode(200);
     }
 


### PR DESCRIPTION
Utilizes the existing `reported` column to keep track of what user is being reported from user reports. This will fix the randomized reports after a canvas resets, as reports currently go off of the reported pixel's ID.

This is not retroactive, user reports will only be correctly entered from the time this is deployed.