### PR TITLE
Fix incorrect cursor position when selecting color with j/k after placing a pixel

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1675,9 +1675,6 @@ window.App = (function () {
                         self.update(evt.clientX, evt.clientY);
                     });
                     $(window).on("pointermove mousemove touchstart touchmove", function (evt) {
-                        if (self.color === -1) {
-                            return;
-                        }
                         let x = 0,
                             y = 0;
                         if (evt.changedTouches && evt.changedTouches[0]) {


### PR DESCRIPTION
Fixes a graphical bug reported in the discord which results in the cursor being in the correct position after placing a pixel and using j/k to cycle colors. Only happens when "Keep color selected" is off.

I opted to straight remove the offending snippet because it's irrelevant when someone has "Keep color selected" on, and there have been no mentions of performance issues (that I've seen anyway).