### PR TITLE
Fix clipboard being incorrectly overwritten by "coordinates copying" feature

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2347,7 +2347,7 @@ window.App = (function () {
                     }
 
                     $(window).keydown(event => {
-                        if ((event.key === "c" || event.key === "C" || event.keyCode === 67) && navigator.clipboard && self.mouseCoords) {
+                        if (!event.ctrlKey && (event.key === "c" || event.key === "C" || event.keyCode === 67) && navigator.clipboard && self.mouseCoords) {
                             navigator.clipboard.writeText(self.getLinkToCoords(self.mouseCoords.x, self.mouseCoords.y));
                             self.elements.coords.addClass("copyPulse");
                             setTimeout(() => {


### PR DESCRIPTION
Currently, if you select some text to copy (e.g. someone's username from lookup results), and press ctrl+c to copy, the copied text will be overwritten with the coordinates under the mouse.

This adds a check for `event.ctrlKey` to that code so that if someone is attempting to ctrl+c, the code will not fire.