### PR TITLE
Display audio error

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2147,7 +2147,7 @@ window.App = (function () {
                     }
 
                     timer.audioElem.addEventListener("error", err => {
-                        alert.show("Your custom alert is either invalid or unplayable.");
+                        alert.show("Your custom alert is either invalid or unplayable. " + err.toString());
                     });
 
                     self.elements.txtAlertLocation.change(function() { //change should only fire on blur so we normally won't be calling updateAudio for each keystroke. just in case though, we'll lazy update.

--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -2185,7 +2185,7 @@ window.App = (function () {
                         timer.audioElem.src = url;
                         ls.set("alert.src", url);
                     } catch (e) {
-                        alert.show("Failed to update audio src, using default sound");
+                        alert.show("Failed to update audio src, using default sound. " + e.toString());
                         timer.audioElem.src = "notify.wav";
                         ls.set("alert.src", "notify.wav");
                     }


### PR DESCRIPTION
Appends `<Error>.toString()` to a couple of audio-changing errors, to help users diagnose their issue.