### PR TITLE
Fix Chrome template rendering at 100% scale

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -966,7 +966,7 @@ window.App = (function () {
                         self.elements.mover.css({
                             width: self.width,
                             height: self.height,
-                            transform: "translate(" + self.pan.x + "px, " + self.pan.y + "px)"
+                            transform: "translate(" + (self.scale <= 1 ? Math.round(self.pan.x) : self.pan.x) + "px, " + (self.scale <= 1 ? Math.round(self.pan.y) : self.pan.y) + "px)"
                         });
                     }
                     if (self.use_zoom) {


### PR DESCRIPTION
Chrome's nearest neighbor (pixelated) bitmap rendering is wonk when the image is offset by fractional pixels.  For dotted (3x3) templates, this means that they seem to disappear from view.  Using integer pixel offsets fixes this.  Not an issue in FireFox, but fix doesn't hurt it either.  As fractional pixel offsets are meaningless at scales of 1 and below (zooming out), the offsets are rounded at these scales.
Note that I chose to round the value in the code that applies the CSS, rather than rounding the internal value, as I haven't explored any (minor) ramifications that would bring when scaling back up (zooming in).