### PR TITLE
Add duplicate IP detection on new sessions

### DIFF
--- a/src/main/java/space/pxls/data/DAO.java
+++ b/src/main/java/space/pxls/data/DAO.java
@@ -136,11 +136,18 @@ public interface DAO extends Closeable {
             "ban_reason VARCHAR(512) NOT NULL DEFAULT ''," +
             "user_agent VARCHAR(512) NOT NULL DEFAULT ''," +
             "pixel_count INT UNSIGNED NOT NULL DEFAULT 0," +
+            "last_ip_alert INT(1) NOT NULL DEFAULT 0, " +
             "pixel_count_alltime INT UNSIGNED NOT NULL DEFAULT 0)")
     void createUsersTable();
 
+    @SqlQuery("SELECT EXISTS(SELECT * FROM users WHERE id = :uid AND last_ip_alert = 1)")
+    boolean userLastIPAlerted(@Bind("uid") int uid);
+
     @SqlQuery("SELECT EXISTS(SELECT 1 FROM users WHERE (last_ip = INET6_ATON(:ip) OR signup_ip = INET6_ATON(:ip)) AND id <> :uid)")
     boolean haveDupeIp(@Bind("ip") String ip, @Bind("uid") int uid);
+
+    @SqlUpdate("UPDATE users SET last_ip_alert=1 WHERE id=:uid")
+    void flagLastIPAlertedOnUID(@Bind("uid") int uid);
 
     @SqlUpdate("UPDATE users SET cooldown_expiry = now() + INTERVAL :seconds SECOND WHERE id = :id")
     void updateUserTime(@Bind("id") int userId, @Bind("seconds") long sec);

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -315,8 +315,21 @@ public class Database implements Closeable {
         return getHandle().haveDupeIp(ip, uid);
     }
 
+    public boolean userLastIPAlerted(User u) {
+        return userLastIPAlerted(u.getId());
+    }
+
+    public boolean userLastIPAlerted(int uid) {
+        return getHandle().userLastIPAlerted(uid);
+    }
+
     public void addLookup(Integer who, String ip) {
         getHandle().putLookup(who, ip);
+    }
+
+    public void doLastIPAlert(User user) {
+        getHandle().flagLastIPAlertedOnUID(user.getId());
+        getHandle().addServerReport("User is on the same network as someone else's last known network(s)", user.getId());
     }
 
     class DatabaseHandle {

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -71,6 +71,11 @@ public class PacketHandler {
             user.setInitialAuthTime(System.currentTimeMillis());
             user.tickStack(false); // pop the whole pixel stack
             sendAvailablePixels(channel, user, "connect");
+
+            App.getDatabase().updateUserIP(user, channel.getSourceAddress().getHostName());
+            if (!App.getDatabase().userLastIPAlerted(user) && App.getDatabase().haveDupeIp(channel.getSourceAddress().getHostName(), user.getId())) {
+                App.getDatabase().doLastIPAlert(user);
+            }
         }
         numAllCons++;
 

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -274,15 +274,10 @@ public class WebHandler {
             return;
         }
 
-        System.out.println("new user");
-        System.out.println(ip);
-        System.out.println(user.getId());
-
         // do additional checks for possible multi here
         List<String> reports = new ArrayList<String>();
         if (App.getDatabase().haveDupeIp(ip, user.getId())) {
             reports.add("Duplicate IP");
-            System.out.println("dupe ip");
         }
         if (reports.size() > 0) {
             System.out.println("have reports");


### PR DESCRIPTION
Adds a column to the `users` table, production SQL will need updated. See modified DAO.java:139

This PR adds code that updates a users IP when new sessions are created and checks for duplicate IPs. If there's a duplicate IP (uses existing dupe check for signups) then it adds a server report. Only alerts once per account. I also took this opportunity to remove some old debug stdouts.