### PR TITLE
Add configurable background pixel cooldown multiplier

### DIFF
--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -80,6 +80,13 @@ activityCooldown {
 
 selfPixelTimeIncrease: true
 
+// Cooldown multiplier for placing on non-background pixels
+backgroundPixel {
+  enabled: true
+  // This multiplies the final cooldown in seconds
+  multiplier: 1.6
+}
+
 // System host, used for various things
 host: ""
 

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -223,8 +223,8 @@ public class PacketHandler {
                 int c_old = c;
                 if (canPlace) {
                     int seconds = getCooldown();
-                    if (c_old != 0xFF && c_old != -1 && App.getDatabase().shouldPixelTimeIncrease(cp.getX(), cp.getY(), user.getId())) {
-                        seconds = (int)Math.round(seconds * 1.6);
+                    if (c_old != 0xFF && c_old != -1 && App.getDatabase().shouldPixelTimeIncrease(cp.getX(), cp.getY(), user.getId()) && App.getConfig().getBoolean("backgroundPixel.enabled")) {
+                        seconds = (int)Math.round(seconds * App.getConfig().getDouble("backgroundPixel.multiplier"));
                     }
                     if (user.isShadowBanned()) {
                         // ok let's just pretend to set a pixel...


### PR DESCRIPTION
Instead of forcing a 1.6x cooldown multiplier on non-background pixels, it's better to have this configurable.