### PR TITLE
Add configurable captcha option for alltime

### DIFF
--- a/resources/reference.conf
+++ b/resources/reference.conf
@@ -96,6 +96,7 @@ captcha {
   key: ""
   secret: ""
   maxPixels: 0
+  allTime: true
 }
 
 stacking {

--- a/src/main/java/space/pxls/data/DAO.java
+++ b/src/main/java/space/pxls/data/DAO.java
@@ -178,6 +178,9 @@ public interface DAO extends Closeable {
     @SqlQuery("SELECT pixel_count FROM users WHERE id = :id")
     DBUserPixelCount getUserPixels(@Bind("id") int userId);
 
+    @SqlQuery("SELECT pixel_count_alltime FROM users WHERE id = :id")
+    DBUserPixelCountAllTime getUserPixelsAllTime(@Bind("id") int userId);
+
     @SqlQuery("SELECT EXISTS(SELECT 1 FROM pixels WHERE x = :x AND y = :y AND most_recent)")
     boolean didPixelChange(@Bind("x") int x, @Bind("y") int y);
 

--- a/src/main/java/space/pxls/data/DBUserPixelCountAllTime.java
+++ b/src/main/java/space/pxls/data/DBUserPixelCountAllTime.java
@@ -1,0 +1,25 @@
+package space.pxls.data;
+
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import space.pxls.user.Role;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+
+public class DBUserPixelCountAllTime {
+    public int pixel_count_alltime;
+    public DBUserPixelCountAllTime(int count) {
+        this.pixel_count_alltime = count;
+    }
+
+    public static class Mapper implements ResultSetMapper<DBUserPixelCountAllTime> {
+        @Override
+        public DBUserPixelCountAllTime map(int index, ResultSet r, StatementContext ctx) throws SQLException {
+            return new DBUserPixelCountAllTime(
+                    r.getInt("pixel_count_alltime")
+            );
+        }
+    }
+}

--- a/src/main/java/space/pxls/data/Database.java
+++ b/src/main/java/space/pxls/data/Database.java
@@ -283,6 +283,10 @@ public class Database implements Closeable {
         return getHandle().getUserPixels(id).pixel_count;
     }
 
+    public int getUserPixelsAllTime(int id) {
+        return getHandle().getUserPixelsAllTime(id).pixel_count_alltime;
+    }
+
     public void clearOldSessions() {
         getHandle().clearOldSessions();
     }

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -185,7 +185,8 @@ public class PacketHandler {
             if (doCaptcha) {
                 int pixels = App.getConfig().getInt("captcha.maxPixels");
                 if (pixels != 0) {
-                    doCaptcha = user.getPixels() < pixels;
+                    boolean allTime = App.getConfig().getBoolean("captcha.allTime");
+                    doCaptcha = (allTime ? user.getPixelsAllTime() : user.getPixels()) < pixels;
                 }
             }
             if (user.updateCaptchaFlagPrePlace() && doCaptcha) {

--- a/src/main/java/space/pxls/user/User.java
+++ b/src/main/java/space/pxls/user/User.java
@@ -321,6 +321,10 @@ public class User {
         return App.getDatabase().getUserPixels(this.id);
     }
 
+    public int getPixelsAllTime() {
+        return App.getDatabase().getUserPixelsAllTime(this.id);
+    }
+
     public int getAvailablePixels() {
         boolean canPlace = canPlace();
         if (!canPlace) return 0;


### PR DESCRIPTION
This allows operators to switch between showing captcha on a current canvas basis (before) or an all-time basis.