### PR TITLE
Change multi-line report message to single-line

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -1887,7 +1887,7 @@ window.App = (function () {
                                 }
                                 msg = textarea;
                             } else if (textarea !== "") {
-                                msg += "\n\nAdditional information: " + textarea
+                                msg += "; additional information: " + textarea
                             }
                             $.post("/report", {
                                 id: id,


### PR DESCRIPTION
This commit removes the newlines from the report message and replaces their occurrence with a semicolon. This was done because the admin panel ([Sorunome/PxlsAdmin](https://github.com/Sorunome/PxlsAdmin)) sanitizes incoming reports.