### PR TITLE
Keep color selected across sessions

### DIFF
--- a/resources/public/pxls.js
+++ b/resources/public/pxls.js
@@ -913,6 +913,10 @@ window.App = (function () {
                                 };
                             window.requestAnimationFrame(spiiiiiin);
                         }
+                        let color = ls.get("color");
+                        if (color != null) {
+                            place.switch(parseInt(color));
+                        }
                     }).fail(function () {
                         socket.reconnect();
                     });
@@ -1630,6 +1634,7 @@ window.App = (function () {
                 },
                 switch: function (newColor) {
                     self.color = newColor;
+                    ls.set('color', newColor);
                     $(".palette-color").removeClass("active");
 
                     $("body").toggleClass("show-placeable-bubble", newColor === -1);


### PR DESCRIPTION
This commit will make use of localStorage to save colors across sessions. This will not work across multiple browsers or devices.