### PR TITLE
Add virginmaps

### DIFF
--- a/src/main/java/space/pxls/server/UndertowServer.java
+++ b/src/main/java/space/pxls/server/UndertowServer.java
@@ -52,6 +52,7 @@ public class UndertowServer {
                 .addPrefixPath("/info", webHandler::info)
                 .addPrefixPath("/boarddata", webHandler::data)
                 .addPrefixPath("/heatmap", webHandler::heatmap)
+                .addPrefixPath("/virginmap", webHandler::virginmap)
                 .addPrefixPath("/logout", webHandler::logout)
                 .addPrefixPath("/lookup", new RateLimitingHandler(webHandler::lookup, (int) App.getConfig().getDuration("server.limits.lookup.time", TimeUnit.SECONDS), App.getConfig().getInt("server.limits.lookup.count")))
                 .addPrefixPath("/report", new RoleGate(Role.USER, webHandler::report))

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -477,6 +477,13 @@ public class WebHandler {
         exchange.getResponseSender().send(ByteBuffer.wrap(App.getHeatmapData()));
     }
 
+    public void virginmap(HttpServerExchange exchange) {
+        exchange.getResponseHeaders()
+                .put(Headers.CONTENT_TYPE, "application/binary")
+                .put(HttpString.tryFromString("Access-Control-Allow-Origin"), "*");
+        exchange.getResponseSender().send(ByteBuffer.wrap(App.getVirginmapData()));
+    }
+
     public void logout(HttpServerExchange exchange) {
         Cookie tokenCookie = exchange.getRequestCookies().get("pxls-token");
 


### PR DESCRIPTION
This PR adds virginmaps. `/virginmap` will return a binary file (like other `*maps`) that indicates 1 if the pixel is a virgin, and 0 if it has been placed on. Linked below is the Python 3 script used to generate said virginmap, if it is implemented mid-canvas. A future PR will be submitted to generate the virginmap on restart.

[generate.py.zip](https://github.com/xSke/Pxls/files/2592488/generate.py.zip)

