### PR TITLE
Disallow Hammer and Sickle

### DIFF
--- a/resources/public/info.html
+++ b/resources/public/info.html
@@ -7,7 +7,7 @@
 		<h1>Rules</h1>
 		<p>We pride ourselves on trying to keep an open canvas for all free from outside interference on our end, and especially censorship. However, for the good of the community and on accounts of our own beliefs, please acknowledge and obey the following guidelines:</p>
 		<ol>
-			<li>No hateful imagery or derogatory speech. This includes but is not limited to words such as <i>faggot</i>, <i>nigger</i>, etc; as well as the Swastika, and any symbols of terrorism.</li>
+			<li>No hateful imagery or derogatory speech. This includes but is not limited to words such as <i>faggot</i>, <i>nigger</i>, etc; as well as the Swastika, Hammer and Sickle, and any symbols of terrorism.</li>
 			<li>No nudity on the canvas. The general rating for artwork is PG-13.</li>
 			<li>No more than <b>one</b> account per user, no exceptions. Multiple account users will be banned from creating art on the canvas.</li>
 			<li>No auto-placement tools of any kind, you must place the pixels manually.</li>


### PR DESCRIPTION
This commit adds the Hammer and Sickle as an example of hate speech; as per rule #1.