### PR TITLE
Stabilize build process

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 
     <properties>
         <kotlin.version>1.2.40</kotlin.version>
+	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>
@@ -44,6 +45,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+		<version>3.8.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
@@ -95,6 +97,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+		<version>3.1.1</version>
                 <configuration>
                     <archive>
                         <manifest>


### PR DESCRIPTION
This commit adds specific version numbers to the maven-compiler-plugin
and maven-jar-plugin entries, and adds UTF-8 as the project source
encoding.

I was tired of seeing those warnings. Only warnings left now are with [google/closure-compiler](https://github.com/google/closure-compiler) not recognizing the JSDoc and RESTful parameter for hooks properly.