### PR TITLE
Reset alert delay input type

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -112,7 +112,7 @@
                     <input type="range" id="rangeAlertVolume" min=0 max=1 step=".01" value=1>
                     <span id="lblAlertVolume"></span>
                 </div>
-				<label style="display: block;">Delay (Seconds): <input type="number" width="30px" value="0" id="alertDelay"></label>
+				<label style="display: block;">Delay (Seconds): <input width="30px" value="0" id="alertDelay"></label>
             </div>
         </div>
         <div class="open">settings</div>


### PR DESCRIPTION
Some mobile browsers do not give the option of having a negative sign. Invalid input is not alerted to the user.