### PR TITLE
Update adminlog for bans, update console ban lengths

### DIFF
--- a/src/main/java/space/pxls/App.java
+++ b/src/main/java/space/pxls/App.java
@@ -154,7 +154,7 @@ public class App {
                 if (user != null) {
                     String reason = line.substring(token[0].length() + token[1].length() + 2).trim();
                     user.ban(24 * 60 * 60, reason);
-                    database.adminLogServer("ban "+user.getName());
+                    database.adminLogServer(String.format("ban %s with reason: %s", user.getName(), reason));
                     System.out.println("Banned " + user.getName() + " for 24 hours.");
                 } else {
                     System.out.println("Cannot find user " + token[1]);
@@ -164,7 +164,7 @@ public class App {
                 if (user != null) {
                     String reason = line.substring(token[0].length() + token[1].length() + 2).trim();
                     user.permaban(reason);
-                    database.adminLogServer("permaban "+user.getName());
+                    database.adminLogServer(String.format("permaban %s with reason: %s", user.getName(), reason));
                     System.out.println("Permabanned " + user.getName());
                 } else {
                     System.out.println("Cannot find user " + token[1]);
@@ -174,7 +174,7 @@ public class App {
                 if (user != null) {
                     String reason = line.substring(token[0].length() + token[1].length() + 2).trim();
                     user.shadowban(reason);
-                    database.adminLogServer("shadowban "+user.getName());
+                    database.adminLogServer(String.format("shadowban %s with reason: %s", user.getName(), reason));
                     System.out.println("Shadowbanned " + user.getName());
                 } else {
                     System.out.println("Cannot find user " + token[1]);

--- a/src/main/java/space/pxls/server/PacketHandler.java
+++ b/src/main/java/space/pxls/server/PacketHandler.java
@@ -118,15 +118,15 @@ public class PacketHandler {
 
     private void handleShadowBanMe(WebSocketChannel channel, User user, ClientShadowBanMe obj) {
         if (user.getRole().greaterEqual(Role.USER)) {
-            App.getDatabase().adminLog("self-shadowban via script", user.getId());
+            App.getDatabase().adminLog(String.format("shadowban %s with reason: self-shadowban via script", user.getName()), user.getId());
             user.shadowban("auto-ban via script", 999*24*3600);
         }
     }
 
     private void handleBanMe(WebSocketChannel channel, User user, ClientBanMe obj) {
-        App.getDatabase().adminLog("self-ban via script", user.getId());
         String app = obj.getApp();
-        user.ban(86400, "auto-ban via script (ap: " + app + ")");
+        App.getDatabase().adminLog(String.format("shadowban %s with reason: auto-ban via script (ap: %s)", user.getName(), app), user.getId());
+        user.permaban(String.format("auto-ban via script(ap: %s)", app), 0);
     }
 
     private void handleCooldownOverride(WebSocketChannel channel, User user, ClientAdminCooldownOverride obj) {

--- a/src/main/java/space/pxls/server/WebHandler.java
+++ b/src/main/java/space/pxls/server/WebHandler.java
@@ -165,7 +165,7 @@ public class WebHandler {
                 time = time_form.getValue();
             }
             if (doLog(exchange)) {
-                App.getDatabase().adminLog("ban " + user.getName(), user_perform.getId());
+                App.getDatabase().adminLog(String.format("ban %s with reason: %s", user.getName(), getBanReason(exchange)), user_perform.getId());
             }
             user.ban(Integer.parseInt(time), getBanReason(exchange), getRollbackTime(exchange));
             exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/text");
@@ -197,7 +197,7 @@ public class WebHandler {
             user.permaban(getBanReason(exchange), getRollbackTime(exchange));
             exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/text");
             if (doLog(exchange)) {
-                App.getDatabase().adminLog("permaban " + user.getName(), user_perform.getId());
+                App.getDatabase().adminLog(String.format("permaban %s with reason: %s", user.getName(), getBanReason(exchange)), user_perform.getId());
             }
             exchange.setStatusCode(200);
         } else {
@@ -212,7 +212,7 @@ public class WebHandler {
             user.shadowban(getBanReason(exchange), getRollbackTime(exchange));
             exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/text");
             if (doLog(exchange)) {
-                App.getDatabase().adminLog("shadowban " + user.getName(), user_perform.getId());
+                App.getDatabase().adminLog(String.format("shadowban %s with reason: %s", user.getName(), getBanReason(exchange)), user_perform.getId());
             }
             exchange.setStatusCode(200);
         } else {
@@ -273,10 +273,6 @@ public class WebHandler {
             respond(exchange, StatusCodes.BAD_REQUEST, new Error("bad_username", "Username taken, try another?"));
             return;
         }
-
-        System.out.println("new user");
-        System.out.println(ip);
-        System.out.println(user.getId());
 
         // do additional checks for possible multi here
         List<String> reports = new ArrayList<String>();


### PR DESCRIPTION
This update brings the following:
* Bans now log the ban reason to the admin_log in a parsable format
* Console bans (e.g. `App.banme()`) are now **permanent**.
* Removes some missed debug logging on user registration